### PR TITLE
Style: 전역 스타일 설정

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,6 +21,10 @@ module.exports = {
       { allowConstantExport: true },
     ],
     'react/react-in-jsx-scope': 'off',
+    'react/function-component-definition': [
+      2,
+      { namedComponents: 'arrow-function' },
+    ],
   },
   parserOptions: {
     ecmaVersion: 'latest',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.21.1",
         "styled-components": "^6.1.3",
+        "styled-reset": "^4.5.1",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -5031,6 +5032,17 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/styled-reset": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.5.1.tgz",
+      "integrity": "sha512-6EvFWZRwaFRFxiPYMwmnzOe33rDkw5r9jIU0eEi49bkt6VSrvjeMp2ZOw/YFbw5SVs81llIY+5fzHtR2/VBZfQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "styled-components": ">=4.0.0 || >=5.0.0 || >=6.0.0"
+      }
     },
     "node_modules/stylis": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.1",
     "styled-components": "^6.1.3",
+    "styled-reset": "^4.5.1",
     "zustand": "^4.4.7"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,12 @@
 import GlobalStyle from './Styles/Global';
 
-function App() {
+const App = () => {
   return (
     <>
       <GlobalStyle />
       hi
     </>
   );
-}
+};
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,12 @@
+import GlobalStyle from './Styles/Global';
+
 function App() {
-  return <div>hi</div>;
+  return (
+    <>
+      <GlobalStyle />
+      hi
+    </>
+  );
 }
 
 export default App;

--- a/src/Assets/Fonts/Fonts.css
+++ b/src/Assets/Fonts/Fonts.css
@@ -1,0 +1,7 @@
+@font-face {
+  font-family: 'Pretendard-Regular';
+  src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff')
+    format('woff');
+  font-weight: 400;
+  font-style: normal;
+}

--- a/src/Styles/Global.ts
+++ b/src/Styles/Global.ts
@@ -40,6 +40,7 @@ const GlobalStyle = createGlobalStyle`
     cursor: pointer;
     background-color: Transparent;
     border: none;
+    user-select: none;
   }
 
   input, button, textarea, select {

--- a/src/Styles/Global.ts
+++ b/src/Styles/Global.ts
@@ -21,7 +21,6 @@ const GlobalStyle = createGlobalStyle`
     color: #333;
     background-color: #f2f2f2;
 
-    font-size: 1.6rem;
     font-family: "Pretendard-Regular", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 
   }

--- a/src/Styles/Global.ts
+++ b/src/Styles/Global.ts
@@ -1,0 +1,51 @@
+import { createGlobalStyle } from 'styled-components';
+import reset from 'styled-reset';
+
+const GlobalStyle = createGlobalStyle`
+  ${reset}
+
+  html {
+    box-sizing: border-box;
+    font-size: 16px;
+  }
+  
+  *, *:before, *:after {
+    box-sizing: inherit;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+    line-height: 1.5;
+    color: #333;
+    background-color: #f2f2f2;
+
+    font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  button {
+    cursor: pointer;
+    background-color: Transparent;
+    border: none;
+  }
+
+  input, button, textarea, select {
+    font-family: inherit;
+  }
+
+  ol, ul{
+    list-style: none;
+  }
+`;
+
+export default GlobalStyle;

--- a/src/Styles/Global.ts
+++ b/src/Styles/Global.ts
@@ -1,12 +1,13 @@
 import { createGlobalStyle } from 'styled-components';
 import reset from 'styled-reset';
+import '../Assets/Fonts/Fonts.css';
 
 const GlobalStyle = createGlobalStyle`
   ${reset}
 
   html {
     box-sizing: border-box;
-    font-size: 16px;
+    font-size: 62.5%;
   }
   
   *, *:before, *:after {
@@ -20,7 +21,9 @@ const GlobalStyle = createGlobalStyle`
     color: #333;
     background-color: #f2f2f2;
 
-    font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+    font-size: 1.6rem;
+    font-family: "Pretendard-Regular", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+
   }
 
   a {


### PR DESCRIPTION
## 🔗 Issue
-

## 📝 Description
모든 컴포넌트에게 기본으로 적용되는 스타일들을 초기화하고 폰트를 적용하였습니다. 추가로 설치한 라이브러리가 있으니, pull 이후 `npm install`을 통해 설치해주세요.

## ✅ CheckList
- [x] css reset을 위한 `styled-reset` 라이브러리 설치 ea6de3eacf0ed6763eecf7a0198fe81da3b79bbb
- [x] element 스타일 및 폰트 초기화 ea6de3eacf0ed6763eecf7a0198fe81da3b79bbb
- [x] App 컴포넌트 선언 방식 변경 d805920b15dfb095948f05654ee7e27141b4bffe
- [x] 반응형 단위 및 font-face 초기화 808a2b1333a794b838dccbdc597994e3cf66ca8f

## 🤔 Ask
-

## 💬 Etc
1. approve 이전에 조절할 수치들이나, 추가적으로 적용해야될 것들 함께 얘기해보면 좋을 듯 합니다.
2. App 컴포넌트 화살표 함수로 바꾸고 깃헙에서 충돌처리 하니 로그가 하나 생겼네요 (0076cb901b47497469939f152087df1cd4e00725)
3. [font-family](https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/pull/1/files#diff-e7c9cb6605fd4e067a96294133b7721716a1642343b82f9204c344f536d945baR25)는 웹 호환성을 고려하여 [제작자](https://github.com/orioncactus/pretendard?tab=readme-ov-file#font-family)가 권장하는 구성을 사용하였습니다.