### PR TITLE
Feat: Button 컴포넌트 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,25 +2,12 @@ import { ThemeProvider } from 'styled-components';
 import { lightTheme } from '@/Styles/Theme';
 import GlobalStyle from '@/Styles/Global';
 import RouteManager from '@/Routes/Router';
-import Button from './Components/Base/Button';
 
 const App = () => {
-  const handleClick = (isActive: boolean) => {
-    console.log(isActive);
-  };
-
   return (
     <ThemeProvider theme={lightTheme}>
       <GlobalStyle />
       <RouteManager />
-      <Button
-        width="12rem"
-        isToggleButton
-        style={{ padding: '10px 20px' }}
-        onClick={handleClick}
-      >
-        버튼
-      </Button>
     </ThemeProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,25 @@ import { ThemeProvider } from 'styled-components';
 import { lightTheme } from '@/Styles/Theme';
 import GlobalStyle from '@/Styles/Global';
 import RouteManager from '@/Routes/Router';
+import Button from './Components/Base/Button';
 
 const App = () => {
+  const handleClick = (isActive: boolean) => {
+    console.log(isActive);
+  };
+
   return (
     <ThemeProvider theme={lightTheme}>
       <GlobalStyle />
       <RouteManager />
+      <Button
+        width="12rem"
+        isToggleButton
+        style={{ padding: '10px 20px' }}
+        onClick={handleClick}
+      >
+        버튼
+      </Button>
     </ThemeProvider>
   );
 };

--- a/src/Components/Base/Button/index.tsx
+++ b/src/Components/Base/Button/index.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import StyledButton from './style';
+import type { ButtonProp } from './type';
+
+const Button = ({
+  children,
+  color,
+  width,
+  height,
+  borderRound,
+  isToggle = false,
+  onClick = () => {},
+  onActiveChange = () => {},
+}: ButtonProp) => {
+  const [isActive, setIsActive] = useState(false);
+
+  const handleClick = () => {
+    if (isToggle) {
+      setIsActive(!isActive);
+      onActiveChange(isActive);
+
+      return;
+    }
+
+    onClick();
+  };
+
+  return (
+    <StyledButton
+      onClick={handleClick}
+      $color={color}
+      $width={width}
+      $height={height}
+      $borderRound={borderRound}
+      $isActive={isActive}
+    >
+      {children}
+    </StyledButton>
+  );
+};
+
+export default Button;

--- a/src/Components/Base/Button/index.tsx
+++ b/src/Components/Base/Button/index.tsx
@@ -2,37 +2,51 @@ import { useState } from 'react';
 import StyledButton from './style';
 import type { ButtonProp } from './type';
 
+/**
+ *
+ * @param param0
+ * @returns
+ */
+
 const Button = ({
   children,
-  color,
-  width,
-  height,
-  borderRound,
-  isToggle = false,
-  onClick = () => {},
-  onActiveChange = () => {},
+  backgroundColor = 'default',
+  textColor = 'default',
+  textSize = 'default',
+  width = 'default',
+  height = 'default',
+  borderRadius = 'default',
+  isToggleButton = false,
+  onClick,
+  style,
 }: ButtonProp) => {
   const [isActive, setIsActive] = useState(false);
 
   const handleClick = () => {
-    if (isToggle) {
-      setIsActive(!isActive);
-      onActiveChange(isActive);
-
-      return;
+    if (onClick) {
+      onClick();
     }
+  };
 
-    onClick();
+  const handleToggle = () => {
+    setIsActive(!isActive);
+
+    if (onClick) {
+      onClick(isActive);
+    }
   };
 
   return (
     <StyledButton
-      onClick={handleClick}
-      $color={color}
+      onClick={isToggleButton ? handleToggle : handleClick}
+      $backgroundColor={backgroundColor}
+      $textColor={textColor}
+      $textSize={textSize}
       $width={width}
       $height={height}
-      $borderRound={borderRound}
+      $borderRadius={borderRadius}
       $isActive={isActive}
+      style={{ ...style }}
     >
       {children}
     </StyledButton>

--- a/src/Components/Base/Button/index.tsx
+++ b/src/Components/Base/Button/index.tsx
@@ -3,9 +3,8 @@ import StyledButton from './style';
 import type { ButtonProp } from './type';
 
 /**
- *
- * @param param0
- * @returns
+ * props에 존재하는 속성들은 해당 prop들을 통해 변경해주세요.
+ * style={{ padding: '10px 20px' }} 과 같이 프롭스에 없는 스타일을 부여해줄 수 있습니다.
  */
 
 const Button = ({
@@ -17,22 +16,22 @@ const Button = ({
   height = 'default',
   borderRadius = 'default',
   isToggleButton = false,
-  onClick,
+  onClickButton,
   style,
 }: ButtonProp) => {
   const [isActive, setIsActive] = useState(false);
 
   const handleClick = () => {
-    if (onClick) {
-      onClick();
+    if (onClickButton) {
+      onClickButton();
     }
   };
 
   const handleToggle = () => {
     setIsActive(!isActive);
 
-    if (onClick) {
-      onClick(isActive);
+    if (onClickButton) {
+      onClickButton(isActive);
     }
   };
 

--- a/src/Components/Base/Button/style.ts
+++ b/src/Components/Base/Button/style.ts
@@ -1,0 +1,71 @@
+import { styled, css } from 'styled-components';
+
+const buttonColorPreset = {
+  default: css`
+    background-color: ${(props) => props.theme.colors.buttonBackground};
+    color: ${(props) => props.theme.colors.buttonText};
+  `,
+  black: css`
+    background-color: #000000;
+    color: #ffffff;
+  `,
+  gray: css`
+    background-color: #e0e0e0;
+    color: #ffffff;
+  `,
+  white: css`
+    background-color: #ffffff;
+    color: #000000;
+  `,
+  blue: css`
+    background-color: #0095f6;
+    color: #ffffff;
+  `,
+  purple: css`
+    background-color: #7752fe;
+    color: #ffffff;
+  `,
+  transparent: css`
+    background-color: transparent;
+    color: ${(props) => props.theme.colors.text};
+  `,
+};
+
+const buttonBorderRoundPreset = {
+  none: css`
+    border-radius: none;
+  `,
+  sm: css`
+    border-radius: ${(props) => props.theme.size.small};
+  `,
+  md: css`
+    border-radius: ${(props) => props.theme.size.medium};
+  `,
+  lg: css`
+    border-radius: ${(props) => props.theme.size.large};
+  `,
+
+  // TODO: Hover 효과
+};
+
+const StyledButton = styled.button<{
+  $color: 'default' | 'black' | 'gray' | 'white' | 'blue' | 'purple';
+  $width: number;
+  $height: number;
+  $borderRound: 'none' | 'sm' | 'md' | 'lg';
+  $isActive: boolean;
+}>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: ${({ $width }) => `${$width}rem`};
+  height: ${({ $height }) => `${$height}rem`};
+
+  ${({ $color }) => $color && buttonColorPreset[$color]}
+  ${({ $borderRound }) =>
+    $borderRound && buttonBorderRoundPreset[$borderRound]};
+  ${({ $isActive }) => $isActive && 'background-color: #000000;'};
+`;
+
+export default StyledButton;

--- a/src/Components/Base/Button/style.ts
+++ b/src/Components/Base/Button/style.ts
@@ -1,71 +1,40 @@
-import { styled, css } from 'styled-components';
+import { styled } from 'styled-components';
+import type { StyledButtonProp } from './type';
 
-const buttonColorPreset = {
-  default: css`
-    background-color: ${(props) => props.theme.colors.buttonBackground};
-    color: ${(props) => props.theme.colors.buttonText};
-  `,
-  black: css`
-    background-color: #000000;
-    color: #ffffff;
-  `,
-  gray: css`
-    background-color: #e0e0e0;
-    color: #ffffff;
-  `,
-  white: css`
-    background-color: #ffffff;
-    color: #000000;
-  `,
-  blue: css`
-    background-color: #0095f6;
-    color: #ffffff;
-  `,
-  purple: css`
-    background-color: #7752fe;
-    color: #ffffff;
-  `,
-  transparent: css`
-    background-color: transparent;
-    color: ${(props) => props.theme.colors.text};
-  `,
-};
-
-const buttonBorderRoundPreset = {
-  none: css`
-    border-radius: none;
-  `,
-  sm: css`
-    border-radius: ${(props) => props.theme.size.small};
-  `,
-  md: css`
-    border-radius: ${(props) => props.theme.size.medium};
-  `,
-  lg: css`
-    border-radius: ${(props) => props.theme.size.large};
-  `,
-
-  // TODO: Hover 효과
-};
-
-const StyledButton = styled.button<{
-  $color: 'default' | 'black' | 'gray' | 'white' | 'blue' | 'purple';
-  $width: number;
-  $height: number;
-  $borderRound: 'none' | 'sm' | 'md' | 'lg';
-  $isActive: boolean;
-}>`
+const StyledButton = styled.button<StyledButtonProp>`
   display: flex;
   justify-content: center;
   align-items: center;
 
-  width: ${({ $width }) => `${$width}rem`};
-  height: ${({ $height }) => `${$height}rem`};
+  /* 받아오는 프롭이 'default'이다? 글로벌 테마 사용 */
+  /* 다른 문자열 값일 경우, 그 값을 부여 */
 
-  ${({ $color }) => $color && buttonColorPreset[$color]}
-  ${({ $borderRound }) =>
-    $borderRound && buttonBorderRoundPreset[$borderRound]};
-  ${({ $isActive }) => $isActive && 'background-color: #000000;'};
+  ${({
+    $backgroundColor,
+    $textColor,
+    $textSize,
+    $width,
+    $height,
+    $borderRadius,
+    $isActive,
+    theme,
+  }) => `
+    background-color: ${
+      $backgroundColor === 'default'
+        ? theme.colors.buttonBackground
+        : $backgroundColor
+    };
+    color: ${$textColor === 'default' ? theme.colors.buttonText : $textColor};
+    font-size: ${$textSize === 'default' ? '1rem' : $textSize};
+    width: ${$width === 'default' ? '120px' : $width};
+    height: ${$height === 'default' ? '10px' : $height};
+    border-radius: ${$borderRadius === 'default' ? '15px' : $borderRadius};
+    ${
+      $isActive
+        ? `background-color: ${theme.colors.focusHover}; color: ${theme.colors.focusHoverText};`
+        : ''
+    }
+  `}
 `;
 
 export default StyledButton;

--- a/src/Components/Base/Button/style.ts
+++ b/src/Components/Base/Button/style.ts
@@ -6,9 +6,6 @@ const StyledButton = styled.button<StyledButtonProp>`
   justify-content: center;
   align-items: center;
 
-  /* 받아오는 프롭이 'default'이다? 글로벌 테마 사용 */
-  /* 다른 문자열 값일 경우, 그 값을 부여 */
-
   ${({
     $backgroundColor,
     $textColor,

--- a/src/Components/Base/Button/type.ts
+++ b/src/Components/Base/Button/type.ts
@@ -1,0 +1,11 @@
+import { ButtonHTMLAttributes } from 'react';
+
+export interface ButtonProp extends ButtonHTMLAttributes<HTMLButtonElement> {
+  color: 'default' | 'black' | 'gray' | 'white' | 'blue' | 'purple';
+  width: number;
+  height: number;
+  borderRound: 'none' | 'sm' | 'md' | 'lg';
+  isToggle?: boolean;
+  onClick?: () => void;
+  onActiveChange?: (state: boolean) => void;
+}

--- a/src/Components/Base/Button/type.ts
+++ b/src/Components/Base/Button/type.ts
@@ -9,8 +9,7 @@ export interface ButtonProp extends ButtonHTMLAttributes<HTMLButtonElement> {
   borderRadius?: 'default' | string;
   isToggleButton?: 'default' | boolean;
 
-  // TODO: isToggleButton=true일 때 active 잘 넘어오는지 체크
-  onClick?: (active?: boolean) => void;
+  onClickButton?: (active?: boolean) => void;
   style?: React.CSSProperties;
 }
 

--- a/src/Components/Base/Button/type.ts
+++ b/src/Components/Base/Button/type.ts
@@ -1,11 +1,26 @@
 import { ButtonHTMLAttributes } from 'react';
 
 export interface ButtonProp extends ButtonHTMLAttributes<HTMLButtonElement> {
-  color: 'default' | 'black' | 'gray' | 'white' | 'blue' | 'purple';
-  width: number;
-  height: number;
-  borderRound: 'none' | 'sm' | 'md' | 'lg';
-  isToggle?: boolean;
-  onClick?: () => void;
-  onActiveChange?: (state: boolean) => void;
+  backgroundColor?: 'default' | string;
+  textColor?: 'default' | string;
+  textSize?: 'default' | string;
+  width?: 'default' | string;
+  height?: 'default' | string;
+  borderRadius?: 'default' | string;
+  isToggleButton?: 'default' | boolean;
+
+  // TODO: isToggleButton=true일 때 active 잘 넘어오는지 체크
+  onClick?: (active?: boolean) => void;
+  style?: React.CSSProperties;
+}
+
+export interface StyledButtonProp
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  $backgroundColor: string;
+  $textColor: string;
+  $textSize: string;
+  $width: string;
+  $height: string;
+  $borderRadius: string;
+  $isActive: boolean;
 }

--- a/src/Styles/Theme.ts
+++ b/src/Styles/Theme.ts
@@ -8,6 +8,7 @@ const commonTheme = {
   backgroundGrey: '#D1CCC7', // 회색 배경 색상
   backgroundWhite: '#FFFFFF', // 배경 흰색 색상
   focusHover: '#F2F2F2', // 포커스 및 호버 색상
+  focusHoverText: '#000000',
   overlay: 'rgba(0, 0, 0, 0.4)', // 오버레이 색상
   buttonClickHover: 'rgba(0, 0, 0, 0.3)', // 버튼 클릭 시 호버 색상
   follow: 'rgba(119, 82, 254, 1)', // 팔로우 색상


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/buttonComponent` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
1. `버튼` 공용 컴포넌트입니다. 색상과 크기, 테두리 둥근 정도를 필수로 전달받고 토글버튼 여부와 콜백함수들을 선택적으로 전달받습니다.
2. 색상(color)과 테두리 둥근 정도(borderRound)는 문자열 형태로 입력받아 프리셋을 통해 부여되도록 구현하였습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] 파라미터 설정 및 `ButtonProp` 타입 부여
- [x] Props 바인딩
- [x] 스타일 프리셋 설정
- [x] 토글 버튼인 경우의 로직 구현

> 피드백 반영

- [x] width, height 선택 속성으로 변경 후 기본값 설정
- [x] 프리셋 삭제 후 기본값 부여
- [x] 콜백 개선 : onClick과 onActiveChage 통합

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 입력 파라미터 관련 개선사항이 있을까요?
- `width`, `height`를 필수 프롭으로 전달받아야 할까요?
- `width`, `height`, `border-radius`에도 반응형 단위가 부여되도록 구현하는게 맞을까요? (테두리가 "`extra-small`rem" 일 때도 너무 둥글어요..ㅜ)
- 토글 버튼일 경우 `isActive` 상태를 통해 토글 여부를 관리하고, `onActiveChange` 콜백을 통해 현재 토글 상태를 상위 컴포넌트에게 전달하는 방식으로 구현해보았는데 보시고 피드백 부탁드립니다.
- 전역 `defaultTheme`의 색상이 다소 한정적이라 `Hover` 효과 구현을 보류하였습니다. 사용되는 색상들이 밝기? 상황?별로 구현된 색상표를 객체 형태로 관리하면 좋을 것 같아요~~
