### PR TITLE
Feat: Common Modal 컴포넌트 구현

### DIFF
--- a/src/Components/Common/Modal/index.tsx
+++ b/src/Components/Common/Modal/index.tsx
@@ -1,20 +1,50 @@
-import { ReactNode } from 'react';
 import styled from 'styled-components';
+import { ModalPropsType, ModalSizeType } from './type';
 
-interface ModalPropsType {
-  children: ReactNode;
-}
+const ModalWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
-const ModalWrapper = styled.div``;
+const ModalBackground = styled.div`
+  background: rgba(0, 0, 0, 0.5);
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  z-index: 5;
+`;
 
-const ModalBackground = styled.div``;
+const ModalContainer = styled.div<ModalSizeType>`
+  background: white;
+  width: ${(props) => props.width}%;
+  height: ${(props) => props.height}%;
+  z-index: 10;
+  overflow: hidden;
+  border-radius: ${(props) => props.radius}px;
+`;
 
-const Modal = ({ children }: ModalPropsType) => {
+const Modal = ({
+  width = 80,
+  height = 80,
+  radius = 5,
+  children,
+}: ModalPropsType) => {
   return (
     <ModalWrapper>
-      Modalwrapper
       <ModalBackground />
-      {children}
+      <ModalContainer
+        width={width}
+        height={height}
+        radius={radius}
+      >
+        {children}
+      </ModalContainer>
     </ModalWrapper>
   );
 };

--- a/src/Components/Common/Modal/index.tsx
+++ b/src/Components/Common/Modal/index.tsx
@@ -1,42 +1,10 @@
-import styled from 'styled-components';
 import { MouseEvent, useRef } from 'react';
+import { ModalPropsType } from './type';
 import {
-  ModalPropsType,
-  StyledModalContainerType,
-  StyledModalWrapperType,
-} from './type';
-
-const StyledModalWrapper = styled.div<StyledModalWrapperType>`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  display: ${(props) => (props.$isOpen ? 'flex' : 'none')};
-  justify-content: center;
-  align-items: center;
-`;
-
-const StyledModalBackground = styled.div`
-  background: rgba(0, 0, 0, 0.5);
-  position: absolute;
-  width: 100%;
-  height: 100%;
-`;
-
-const StyledModalContainer = styled.div<StyledModalContainerType>`
-  width: ${(props) => props.width}%;
-  height: ${(props) => props.height}%;
-  display: flex;
-  z-index: 10;
-  background: white;
-  overflow: hidden;
-  border-radius: ${(props) => props.$borderRadius}px;
-  ${(props) =>
-    props.$flexDirection !== 'row'
-      ? 'flex-direction: column; align-items: center;'
-      : undefined}
-`;
+  StyledModalWrapper,
+  StyledModalBackground,
+  StyledModalContainer,
+} from './style';
 
 const Modal = ({
   children,
@@ -53,7 +21,7 @@ const Modal = ({
    * 모달 바깥 배경을 클릭하면 currentTarget를 확인후
    * 외부 setIsOpen함수에 onChangeOpen 함수를 통해 false 전달하는 함수
    */
-  const handleModalBgClick = (e: MouseEvent) => {
+  const handleModalClose = (e: MouseEvent) => {
     if (e.currentTarget === modalBgRef.current) onChangeOpen(false);
   };
 
@@ -61,7 +29,7 @@ const Modal = ({
     <StyledModalWrapper $isOpen={isOpen}>
       <StyledModalBackground
         ref={modalBgRef}
-        onClick={handleModalBgClick}
+        onClick={handleModalClose}
       />
       <StyledModalContainer
         width={width}

--- a/src/Components/Common/Modal/index.tsx
+++ b/src/Components/Common/Modal/index.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+interface ModalPropsType {
+  children: ReactNode;
+}
+
+const ModalWrapper = styled.div``;
+
+const ModalBackground = styled.div``;
+
+const Modal = ({ children }: ModalPropsType) => {
+  return (
+    <ModalWrapper>
+      Modalwrapper
+      <ModalBackground />
+      {children}
+    </ModalWrapper>
+  );
+};
+
+export default Modal;

--- a/src/Components/Common/Modal/index.tsx
+++ b/src/Components/Common/Modal/index.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
-import { ModalPropsType, ModalSizeType } from './type';
+import { ModalPropsType, ModalStyleType } from './type';
 
-const ModalWrapper = styled.div`
+const StyledModalWrapper = styled.div`
   position: absolute;
   top: 0;
   left: 0;
@@ -12,7 +12,7 @@ const ModalWrapper = styled.div`
   align-items: center;
 `;
 
-const ModalBackground = styled.div`
+const StyledModalBackground = styled.div`
   background: rgba(0, 0, 0, 0.5);
   position: absolute;
   width: 100%;
@@ -20,32 +20,39 @@ const ModalBackground = styled.div`
   z-index: 5;
 `;
 
-const ModalContainer = styled.div<ModalSizeType>`
-  background: white;
+const StyledModalContainer = styled.div<ModalStyleType>`
   width: ${(props) => props.width}%;
   height: ${(props) => props.height}%;
+  display: flex;
   z-index: 10;
+  background: white;
   overflow: hidden;
   border-radius: ${(props) => props.radius}px;
+  ${(props) =>
+    props.direction !== 'row'
+      ? 'flex-direction: column; align-items: center;'
+      : undefined}
 `;
 
 const Modal = ({
   width = 80,
   height = 80,
   radius = 5,
+  direction = 'row',
   children,
 }: ModalPropsType) => {
   return (
-    <ModalWrapper>
-      <ModalBackground />
-      <ModalContainer
+    <StyledModalWrapper>
+      <StyledModalBackground />
+      <StyledModalContainer
         width={width}
         height={height}
         radius={radius}
+        direction={direction}
       >
         {children}
-      </ModalContainer>
-    </ModalWrapper>
+      </StyledModalContainer>
+    </StyledModalWrapper>
   );
 };
 

--- a/src/Components/Common/Modal/index.tsx
+++ b/src/Components/Common/Modal/index.tsx
@@ -1,13 +1,18 @@
 import styled from 'styled-components';
-import { ModalPropsType, ModalStyleType } from './type';
+import { MouseEvent, useRef } from 'react';
+import {
+  ModalPropsType,
+  StyledModalContainerType,
+  StyledModalWrapperType,
+} from './type';
 
-const StyledModalWrapper = styled.div`
+const StyledModalWrapper = styled.div<StyledModalWrapperType>`
   position: absolute;
   top: 0;
   left: 0;
   width: 100vw;
   height: 100vh;
-  display: flex;
+  display: ${(props) => (props.$isOpen ? 'flex' : 'none')};
   justify-content: center;
   align-items: center;
 `;
@@ -17,38 +22,52 @@ const StyledModalBackground = styled.div`
   position: absolute;
   width: 100%;
   height: 100%;
-  z-index: 5;
 `;
 
-const StyledModalContainer = styled.div<ModalStyleType>`
+const StyledModalContainer = styled.div<StyledModalContainerType>`
   width: ${(props) => props.width}%;
   height: ${(props) => props.height}%;
   display: flex;
   z-index: 10;
   background: white;
   overflow: hidden;
-  border-radius: ${(props) => props.radius}px;
+  border-radius: ${(props) => props.$borderRadius}px;
   ${(props) =>
-    props.direction !== 'row'
+    props.$flexDirection !== 'row'
       ? 'flex-direction: column; align-items: center;'
       : undefined}
 `;
 
 const Modal = ({
+  children,
   width = 80,
   height = 80,
-  radius = 5,
-  direction = 'row',
-  children,
+  borderRadius = 5,
+  flexDirection = 'row',
+  isOpen,
+  onChangeOpen,
 }: ModalPropsType) => {
+  const modalBgRef = useRef(null);
+
+  /**
+   * 모달 바깥 배경을 클릭하면 currentTarget를 확인후
+   * 외부 setIsOpen함수에 onChangeOpen 함수를 통해 false 전달하는 함수
+   */
+  const handleModalBgClick = (e: MouseEvent) => {
+    if (e.currentTarget === modalBgRef.current) onChangeOpen(false);
+  };
+
   return (
-    <StyledModalWrapper>
-      <StyledModalBackground />
+    <StyledModalWrapper $isOpen={isOpen}>
+      <StyledModalBackground
+        ref={modalBgRef}
+        onClick={handleModalBgClick}
+      />
       <StyledModalContainer
         width={width}
         height={height}
-        radius={radius}
-        direction={direction}
+        $borderRadius={borderRadius}
+        $flexDirection={flexDirection}
       >
         {children}
       </StyledModalContainer>

--- a/src/Components/Common/Modal/style.ts
+++ b/src/Components/Common/Modal/style.ts
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+import { StyledModalContainerType, StyledModalWrapperType } from './type';
+
+export const StyledModalWrapper = styled.div<StyledModalWrapperType>`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: ${(props) => (props.$isOpen ? 'flex' : 'none')};
+  justify-content: center;
+  align-items: center;
+`;
+
+export const StyledModalBackground = styled.div`
+  background: rgba(0, 0, 0, 0.5);
+  position: absolute;
+  width: 100%;
+  height: 100%;
+`;
+
+export const StyledModalContainer = styled.div<StyledModalContainerType>`
+  width: ${(props) => props.width}%;
+  height: ${(props) => props.height}%;
+  display: flex;
+  z-index: 10;
+  background: white;
+  overflow: hidden;
+  border-radius: ${(props) => props.$borderRadius}px;
+  ${(props) =>
+    props.$flexDirection !== 'row'
+      ? 'flex-direction: column; align-items: center;'
+      : undefined}
+`;

--- a/src/Components/Common/Modal/type.ts
+++ b/src/Components/Common/Modal/type.ts
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+export interface ModalPropsType extends ModalSizeType {
+  children: ReactNode;
+}
+
+export interface ModalSizeType {
+  width?: number;
+  height?: number;
+  radius?: number;
+}

--- a/src/Components/Common/Modal/type.ts
+++ b/src/Components/Common/Modal/type.ts
@@ -1,11 +1,12 @@
 import { ReactNode } from 'react';
 
-export interface ModalPropsType extends ModalSizeType {
+export interface ModalPropsType extends ModalStyleType {
   children: ReactNode;
 }
 
-export interface ModalSizeType {
+export interface ModalStyleType {
   width?: number;
   height?: number;
   radius?: number;
+  direction?: 'row' | 'column';
 }

--- a/src/Components/Common/Modal/type.ts
+++ b/src/Components/Common/Modal/type.ts
@@ -1,7 +1,7 @@
-import { ReactNode } from 'react';
+import { ButtonHTMLAttributes, HTMLAttributes } from 'react';
 
-export interface ModalPropsType {
-  children: ReactNode;
+export interface ModalPropsType
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
   width?: number;
   height?: number;
   borderRadius?: number;
@@ -10,10 +10,11 @@ export interface ModalPropsType {
   onChangeOpen: (openState: boolean) => void;
 }
 
-export interface StyledModalWrapperType {
+export interface StyledModalWrapperType extends HTMLAttributes<HTMLDivElement> {
   $isOpen: boolean;
 }
-export interface StyledModalContainerType {
+export interface StyledModalContainerType
+  extends HTMLAttributes<HTMLDivElement> {
   width: number;
   height: number;
   $borderRadius: number;

--- a/src/Components/Common/Modal/type.ts
+++ b/src/Components/Common/Modal/type.ts
@@ -1,12 +1,21 @@
 import { ReactNode } from 'react';
 
-export interface ModalPropsType extends ModalStyleType {
+export interface ModalPropsType {
   children: ReactNode;
-}
-
-export interface ModalStyleType {
   width?: number;
   height?: number;
-  radius?: number;
-  direction?: 'row' | 'column';
+  borderRadius?: number;
+  flexDirection?: 'row' | 'column';
+  isOpen: boolean;
+  onChangeOpen: (openState: boolean) => void;
+}
+
+export interface StyledModalWrapperType {
+  $isOpen: boolean;
+}
+export interface StyledModalContainerType {
+  width: number;
+  height: number;
+  $borderRadius: number;
+  $flexDirection: 'row' | 'column';
 }


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/modalComponent` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
Common 재사용 가능한 Modal 컴포넌트를 구현했습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `src/Components/Common/Modal` 폴더 내에 컴포넌트 구현
- [x] `type.ts`로 props 타입 분리
- [x]  width, height, border-radius, flex-direction과 같은 모달 전체 스타일 props로 설정 가능
- [x] `isOpen` props로 모달 열고 닫기 가능
- [x] 외부 `setIsOpen` 함수와 `onChangeOpen` 함수 연결
> 피드백 반영
- [x] handleModalBgClick -> handleModalClose 함수명 변경
- [x] 스타일 컴포넌트 코드 style.ts 파일로 분리
- [x]  스타일 컴포넌트 HTML 기본 Props 타입 추가

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 타입과 스타일 컴포넌트 분리가 제대로 이루어진 건지 봐주세요!
- 원래는 외부 버튼에 대한 ref를 가져와서 이벤트를 설정하려고 했으나 ref가 계속 `null`값으로 받아와져서 포기했어요...
- 대신 모달 선언하는 컴포넌트에서 `isOpen` 상태와 모달을 여는 버튼 컴포넌트를 추가하여 연결만 하면 가능하도록 구현했습니다.
