### PR TITLE
Feat: PostCard 공용 컴포넌트 구현

### DIFF
--- a/src/Components/Common/PostCard/index.tsx
+++ b/src/Components/Common/PostCard/index.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from 'styled-components';
 import { PostCardProps } from './type';
 import {
   StyledPostCardWrapper,
@@ -12,7 +13,6 @@ import {
 } from './style';
 import Icon from '@/Components/Base/Icon';
 import Button from '@/Components/Base/Button';
-import { lightTheme } from '@/Styles/Theme';
 
 const PostCard = ({
   imageUrl,
@@ -25,11 +25,12 @@ const PostCard = ({
   fontSize,
   objectFit = 'fill',
 }: PostCardProps) => {
-  const followBtnBgColor = isFollower
-    ? lightTheme.colors.read
-    : lightTheme.colors.follow;
-
-  const followBtnTextColor = lightTheme.colors.buttonText;
+  const { colors } = useTheme();
+  const followBtnBgColor = isFollower ? colors.read : colors.follow;
+  const followBtnHoverBgColor = isFollower
+    ? 'rgba(0, 149, 246, 0.7)'
+    : 'rgba(119, 82, 254, 0.7)';
+  const followBtnTextColor = colors.buttonText;
 
   return (
     <StyledPostCardWrapper
@@ -53,13 +54,14 @@ const PostCard = ({
             textSize="1rem"
             textColor={followBtnTextColor}
             backgroundColor={followBtnBgColor}
+            hoverBackgroundColor={followBtnHoverBgColor}
           >
             {isFollower ? '팔로잉' : '팔로우'}
           </Button>
         </StyledProfileContainer>
         <Icon
           name={isLike ? 'favorite' : 'favorite_border'}
-          style={HeartIconStyle}
+          style={{ color: `${colors.alert}`, ...HeartIconStyle }}
         />
       </StyledPostCardHeader>
       <StyledPostCardTitle>{content}</StyledPostCardTitle>

--- a/src/Components/Common/PostCard/index.tsx
+++ b/src/Components/Common/PostCard/index.tsx
@@ -6,39 +6,59 @@ import {
   StyledProfileAvatar,
   StyledProfileName,
   StyledProfileContainer,
-  StyledProfileFollowBtn,
   HeartIconStyle,
   StyledPostCardTitle,
-  FillHeartIconStyle,
   StyledPostCardImage,
 } from './style';
 import Icon from '@/Components/Base/Icon';
+import Button from '@/Components/Base/Button';
+import { lightTheme } from '@/Styles/Theme';
 
 const PostCard = ({
   imageUrl,
   content,
   authorName,
-  authorCover,
+  authorThumbnail,
   isFollower,
   isLike,
   width = '80%',
+  fontSize,
 }: PostCardProps) => {
+  const followBtnBgColor = isFollower
+    ? lightTheme.colors.read
+    : lightTheme.colors.follow;
+
+  const followBtnTextColor = lightTheme.colors.buttonText;
+
   return (
-    <StyledPostCardWrapper width={width}>
+    <StyledPostCardWrapper
+      width={width}
+      fontSize={fontSize}
+    >
       <StyledPostCardHeader>
         <StyledProfileContainer>
+          {/* 아바타 컴포넌트 삽입 필요 */}
           <StyledProfileAvatar
-            src={authorCover}
+            src={authorThumbnail}
             alt="프로필 아바타"
           />
           <StyledProfileName>{authorName}</StyledProfileName>
-          <StyledProfileFollowBtn $isFollower={isFollower}>
+          {/* btn hover 배경색 컴포넌트 수정 필요 */}
+          <Button
+            className="follow-btn"
+            width="5rem"
+            height="2rem"
+            borderRadius="0.5rem"
+            textSize="1rem"
+            textColor={followBtnTextColor}
+            backgroundColor={followBtnBgColor}
+          >
             {isFollower ? '팔로잉' : '팔로우'}
-          </StyledProfileFollowBtn>
+          </Button>
         </StyledProfileContainer>
         <Icon
-          name="Favorite"
-          style={isLike ? FillHeartIconStyle : HeartIconStyle}
+          name={isLike ? 'favorite' : 'favorite_border'}
+          style={HeartIconStyle}
         />
       </StyledPostCardHeader>
       <StyledPostCardTitle>{content}</StyledPostCardTitle>

--- a/src/Components/Common/PostCard/index.tsx
+++ b/src/Components/Common/PostCard/index.tsx
@@ -23,6 +23,7 @@ const PostCard = ({
   isLike,
   width = '80%',
   fontSize,
+  objectFit = 'fill',
 }: PostCardProps) => {
   const followBtnBgColor = isFollower
     ? lightTheme.colors.read
@@ -66,6 +67,7 @@ const PostCard = ({
         <StyledPostCardImage
           src={imageUrl}
           alt="포스트 카드 이미지"
+          $objectFit={objectFit}
         />
       </StyledPostCardBody>
     </StyledPostCardWrapper>

--- a/src/Components/Common/PostCard/index.tsx
+++ b/src/Components/Common/PostCard/index.tsx
@@ -1,0 +1,55 @@
+import { PostCardProps } from './type';
+import {
+  StyledPostCardWrapper,
+  StyledPostCardHeader,
+  StyledPostCardBody,
+  StyledProfileAvatar,
+  StyledProfileName,
+  StyledProfileContainer,
+  StyledProfileFollowBtn,
+  HeartIconStyle,
+  StyledPostCardTitle,
+  FillHeartIconStyle,
+  StyledPostCardImage,
+} from './style';
+import Icon from '@/Components/Base/Icon';
+
+const PostCard = ({
+  imageUrl,
+  content,
+  authorName,
+  authorCover,
+  isFollower,
+  isLike,
+  width = '80%',
+}: PostCardProps) => {
+  return (
+    <StyledPostCardWrapper width={width}>
+      <StyledPostCardHeader>
+        <StyledProfileContainer>
+          <StyledProfileAvatar
+            src={authorCover}
+            alt="프로필 아바타"
+          />
+          <StyledProfileName>{authorName}</StyledProfileName>
+          <StyledProfileFollowBtn $isFollower={isFollower}>
+            {isFollower ? '팔로잉' : '팔로우'}
+          </StyledProfileFollowBtn>
+        </StyledProfileContainer>
+        <Icon
+          name="Favorite"
+          style={isLike ? FillHeartIconStyle : HeartIconStyle}
+        />
+      </StyledPostCardHeader>
+      <StyledPostCardTitle>{content}</StyledPostCardTitle>
+      <StyledPostCardBody>
+        <StyledPostCardImage
+          src={imageUrl}
+          alt="포스트 카드 이미지"
+        />
+      </StyledPostCardBody>
+    </StyledPostCardWrapper>
+  );
+};
+
+export default PostCard;

--- a/src/Components/Common/PostCard/index.tsx
+++ b/src/Components/Common/PostCard/index.tsx
@@ -45,7 +45,6 @@ const PostCard = ({
             alt="프로필 아바타"
           />
           <StyledProfileName>{authorName}</StyledProfileName>
-          {/* btn hover 배경색 컴포넌트 수정 필요 */}
           <Button
             className="follow-btn"
             width="5rem"

--- a/src/Components/Common/PostCard/style.ts
+++ b/src/Components/Common/PostCard/style.ts
@@ -1,0 +1,79 @@
+import { styled } from 'styled-components';
+import { lightTheme } from '@/Styles/Theme';
+
+export const StyledPostCardWrapper = styled.div<{ width: string }>`
+  width: ${(props) => props.width};
+  min-width: 15rem;
+  border: 1px solid ${({ theme }) => theme.colors.backgroundGrey};
+  border-radius: 0.5rem;
+  box-shadow: 0.1rem 0.1rem 0.1rem rgba(0, 0, 0, 0.2);
+  aspect-ratio: 1;
+  /* 모드에 따른 기본 배경 색깔 오류있는 듯 */
+  /* background-color: ${({ theme }) => theme.colors.primary}; */
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+export const StyledPostCardHeader = styled.div`
+  padding: 1rem;
+  display: flex;
+  border-radius: 0.5rem 0.5rem 0 0;
+  justify-content: space-between;
+`;
+
+export const StyledProfileContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+`;
+
+export const StyledProfileAvatar = styled.img`
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+`;
+
+export const StyledProfileName = styled.span`
+  font-weight: 700;
+  cursor: pointer;
+`;
+
+export const StyledProfileFollowBtn = styled.button<{ $isFollower: boolean }>`
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  background-color: ${(props) =>
+    props.$isFollower
+      ? ({ theme }) => theme.colors.read
+      : ({ theme }) => theme.colors.follow};
+  color: ${({ theme }) => theme.colors.buttonText};
+  font-size: 1rem;
+
+  &:hover {
+    background-color: ${(props) =>
+      props.$isFollower ? 'rgba(0, 149, 246, 0.7)' : 'rgba(119, 82, 254, 0.7)'};
+  }
+`;
+
+export const HeartIconStyle = {
+  color: `${lightTheme.colors.alert}`,
+  cursor: 'pointer',
+};
+
+export const FillHeartIconStyle = {
+  cursor: 'pointer',
+};
+
+export const StyledPostCardTitle = styled.div`
+  padding-left: 1rem;
+`;
+
+export const StyledPostCardBody = styled.div`
+  width: 100%;
+  height: 100%;
+  border-radius: 0 0 0.5rem 0.5rem;
+`;
+
+export const StyledPostCardImage = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 0 0 0.5rem 0.5rem;
+`;

--- a/src/Components/Common/PostCard/style.ts
+++ b/src/Components/Common/PostCard/style.ts
@@ -1,16 +1,19 @@
 import { styled } from 'styled-components';
 import { lightTheme } from '@/Styles/Theme';
 
-export const StyledPostCardWrapper = styled.div<{ width: string }>`
+export const StyledPostCardWrapper = styled.div<{
+  width: string;
+  fontSize?: string;
+}>`
   width: ${(props) => props.width};
   min-width: 15rem;
   border: 1px solid ${({ theme }) => theme.colors.backgroundGrey};
   border-radius: 0.5rem;
   box-shadow: 0.1rem 0.1rem 0.1rem rgba(0, 0, 0, 0.2);
   aspect-ratio: 1;
-  /* 모드에 따른 기본 배경 색깔 오류있는 듯 */
-  /* background-color: ${({ theme }) => theme.colors.primary}; */
+  background-color: ${({ theme }) => theme.colors.background};
   color: ${({ theme }) => theme.colors.text};
+  font-size: ${(props) => props.fontSize};
 `;
 
 export const StyledPostCardHeader = styled.div`
@@ -58,12 +61,11 @@ export const HeartIconStyle = {
   cursor: 'pointer',
 };
 
-export const FillHeartIconStyle = {
-  cursor: 'pointer',
-};
-
 export const StyledPostCardTitle = styled.div`
   padding-left: 1rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export const StyledPostCardBody = styled.div`

--- a/src/Components/Common/PostCard/style.ts
+++ b/src/Components/Common/PostCard/style.ts
@@ -1,5 +1,4 @@
 import { styled } from 'styled-components';
-import { lightTheme } from '@/Styles/Theme';
 
 export const StyledPostCardWrapper = styled.div<{
   width: string;
@@ -27,7 +26,7 @@ export const StyledPostCardHeader = styled.div`
 
 export const StyledProfileContainer = styled.div`
   display: flex;
-  gap: 0.5rem;
+  gap: 1rem;
   align-items: center;
 `;
 
@@ -38,33 +37,16 @@ export const StyledProfileAvatar = styled.img`
 `;
 
 export const StyledProfileName = styled.span`
-  font-weight: 700;
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
   cursor: pointer;
 `;
 
-export const StyledProfileFollowBtn = styled.button<{ $isFollower: boolean }>`
-  padding: 0.5rem 1rem;
-  border-radius: 0.5rem;
-  background-color: ${(props) =>
-    props.$isFollower
-      ? ({ theme }) => theme.colors.read
-      : ({ theme }) => theme.colors.follow};
-  color: ${({ theme }) => theme.colors.buttonText};
-  font-size: 1rem;
-
-  &:hover {
-    background-color: ${(props) =>
-      props.$isFollower ? 'rgba(0, 149, 246, 0.7)' : 'rgba(119, 82, 254, 0.7)'};
-  }
-`;
-
 export const HeartIconStyle = {
-  color: `${lightTheme.colors.alert}`,
   cursor: 'pointer',
 };
 
 export const StyledPostCardTitle = styled.div`
-  padding-left: 1rem;
+  padding: 0 1rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/Components/Common/PostCard/style.ts
+++ b/src/Components/Common/PostCard/style.ts
@@ -5,6 +5,8 @@ export const StyledPostCardWrapper = styled.div<{
   width: string;
   fontSize?: string;
 }>`
+  display: flex;
+  flex-direction: column;
   width: ${(props) => props.width};
   min-width: 15rem;
   border: 1px solid ${({ theme }) => theme.colors.backgroundGrey};
@@ -70,12 +72,16 @@ export const StyledPostCardTitle = styled.div`
 
 export const StyledPostCardBody = styled.div`
   width: 100%;
-  height: 100%;
+  height: 50%;
   border-radius: 0 0 0.5rem 0.5rem;
+  flex-grow: 1;
 `;
 
-export const StyledPostCardImage = styled.img`
+export const StyledPostCardImage = styled.img<{
+  $objectFit: 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
+}>`
   width: 100%;
   height: 100%;
   border-radius: 0 0 0.5rem 0.5rem;
+  object-fit: ${(props) => props.$objectFit};
 `;

--- a/src/Components/Common/PostCard/type.ts
+++ b/src/Components/Common/PostCard/type.ts
@@ -9,4 +9,5 @@ export interface PostCardProps extends HTMLAttributes<HTMLDivElement> {
   isLike: boolean;
   width?: string;
   fontSize?: string;
+  objectFit?: 'fill' | 'contain' | 'cover' | 'none' | 'scale-down';
 }

--- a/src/Components/Common/PostCard/type.ts
+++ b/src/Components/Common/PostCard/type.ts
@@ -1,0 +1,11 @@
+import { HTMLAttributes } from 'react';
+
+export interface PostCardProps extends HTMLAttributes<HTMLDivElement> {
+  imageUrl: string;
+  content: string;
+  authorName: string;
+  authorCover: string;
+  isFollower: boolean;
+  isLike: boolean;
+  width?: string;
+}

--- a/src/Components/Common/PostCard/type.ts
+++ b/src/Components/Common/PostCard/type.ts
@@ -4,8 +4,9 @@ export interface PostCardProps extends HTMLAttributes<HTMLDivElement> {
   imageUrl: string;
   content: string;
   authorName: string;
-  authorCover: string;
+  authorThumbnail: string;
   isFollower: boolean;
   isLike: boolean;
   width?: string;
+  fontSize?: string;
 }


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/postCard` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
메인 화면에 나타날 포스트 카드를 구현
![image](https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/assets/70748442/e0711a85-cb36-43d4-af20-4154de0e0aec)


<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] PostCard 디자인 및 props 세분화
- [x] 팔로우 버튼 및 좋아요 구현

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 포스트 카드의 크기를 width를 props로 넘겨주게 하고 비율을 1대1 정방형으로 되게 일단 만들었습니다. 크기 조정에 대한 다른 좋은 아이디어가 있다면 알려주세요.
- 아직 Icon과 Button 컴포넌트와 같은 공용 컴포넌트가 완성이 되지 않아 styled 컴포넌트로 대체했습니다. 이후 추가 리팩토링이 필요해보입니다.
