### PR TITLE
Feat: Input 컴포넌트 에러 메세지 출력 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,17 +2,12 @@ import { ThemeProvider } from 'styled-components';
 import { lightTheme } from '@/Styles/Theme';
 import GlobalStyle from '@/Styles/Global';
 import RouteManager from '@/Routes/Router';
-import Input from './Components/Base/Input';
 
 const App = () => {
   return (
     <ThemeProvider theme={lightTheme}>
       <GlobalStyle />
       <RouteManager />
-      <Input
-        errorMessage="ㅗㅑ"
-        label="네임"
-      />
     </ThemeProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,17 @@ import { ThemeProvider } from 'styled-components';
 import { lightTheme } from '@/Styles/Theme';
 import GlobalStyle from '@/Styles/Global';
 import RouteManager from '@/Routes/Router';
+import Input from './Components/Base/Input';
 
 const App = () => {
   return (
     <ThemeProvider theme={lightTheme}>
       <GlobalStyle />
       <RouteManager />
+      <Input
+        errorMessage="ㅗㅑ"
+        label="네임"
+      />
     </ThemeProvider>
   );
 };

--- a/src/Components/Base/Input/index.tsx
+++ b/src/Components/Base/Input/index.tsx
@@ -4,6 +4,7 @@ import {
   StyledInput,
   StyledLabel,
   StyledErrorMessage,
+  StyledContainer,
 } from './style';
 import Props from './type';
 
@@ -29,13 +30,17 @@ const Input = ({
       $block={block}
       {...wrapperProps}
     >
-      {label && <StyledLabel>{label}</StyledLabel>}
+      <StyledContainer>
+        {label && <StyledLabel>{label}</StyledLabel>}
+        {errorMessage && (
+          <StyledErrorMessage>{errorMessage}</StyledErrorMessage>
+        )}
+      </StyledContainer>
       <StyledInput
         $invalid={invalid}
         ref={inputRef}
         {...props}
       />
-      {errorMessage && <StyledErrorMessage>{errorMessage}</StyledErrorMessage>}
     </StyledWrapper>
   );
 };

--- a/src/Components/Base/Input/index.tsx
+++ b/src/Components/Base/Input/index.tsx
@@ -11,7 +11,6 @@ import Props from './type';
 const Input = ({
   label,
   initialFocus = false,
-  invalid = false,
   block = false,
   wrapperProps,
   errorMessage,
@@ -37,7 +36,7 @@ const Input = ({
         )}
       </StyledContainer>
       <StyledInput
-        $invalid={invalid}
+        $invalid={!!errorMessage}
         ref={inputRef}
         {...props}
       />

--- a/src/Components/Base/Input/index.tsx
+++ b/src/Components/Base/Input/index.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef } from 'react';
-import { StyledWrapper, StyledInput, StyledLabel } from './style';
+import {
+  StyledWrapper,
+  StyledInput,
+  StyledLabel,
+  StyledErrorMessage,
+} from './style';
 import Props from './type';
 
 const Input = ({
@@ -8,6 +13,7 @@ const Input = ({
   invalid = false,
   block = false,
   wrapperProps,
+  errorMessage,
   ...props
 }: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -29,8 +35,8 @@ const Input = ({
         ref={inputRef}
         {...props}
       />
+      {errorMessage && <StyledErrorMessage>{errorMessage}</StyledErrorMessage>}
     </StyledWrapper>
   );
 };
-
 export default Input;

--- a/src/Components/Base/Input/style.ts
+++ b/src/Components/Base/Input/style.ts
@@ -12,7 +12,7 @@ export const StyledLabel = styled.label`
 
 export const StyledInput = styled.input<{ $invalid?: boolean }>`
   width: 100%;
-  padding: ${({ theme }) => `${theme.size.extraSmall}${theme.size.small}`};
+  padding: ${({ theme }) => `${theme.size.extraSmall} ${theme.size.small}`};
   border: 1px solid
     ${({ $invalid, theme }) =>
       $invalid ? theme.colors.alert : theme.colors.border};

--- a/src/Components/Base/Input/style.ts
+++ b/src/Components/Base/Input/style.ts
@@ -12,9 +12,14 @@ export const StyledLabel = styled.label`
 
 export const StyledInput = styled.input<{ $invalid?: boolean }>`
   width: 100%;
-  padding: 4px 8px;
+  padding: ${({ theme }) => `${theme.size.extraSmall}${theme.size.small}`};
   border: 1px solid
     ${({ $invalid, theme }) =>
       $invalid ? theme.colors.alert : theme.colors.border};
-  border-radius: ${({ theme }) => theme.size.extraSmall};
+  border-radius: ${({ theme }) => theme.size.small};
+`;
+
+export const StyledErrorMessage = styled.p`
+  color: ${({ theme }) => theme.colors.alert};
+  font-size: ${({ theme }) => theme.size.medium};
 `;

--- a/src/Components/Base/Input/style.ts
+++ b/src/Components/Base/Input/style.ts
@@ -3,11 +3,17 @@ import styled from 'styled-components';
 export const StyledWrapper = styled.div<{ $block?: boolean }>`
   display: ${({ $block }) => ($block ? 'block' : 'inline-block')};
   color: ${({ theme }) => theme.colors.text};
+  font-size: ${({ theme }) => theme.size.medium};
+`;
+
+export const StyledContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.size.small};
 `;
 
 export const StyledLabel = styled.label`
   display: block;
-  font-size: ${({ theme }) => theme.size.medium};
 `;
 
 export const StyledInput = styled.input<{ $invalid?: boolean }>`
@@ -21,5 +27,4 @@ export const StyledInput = styled.input<{ $invalid?: boolean }>`
 
 export const StyledErrorMessage = styled.p`
   color: ${({ theme }) => theme.colors.alert};
-  font-size: ${({ theme }) => theme.size.medium};
 `;

--- a/src/Components/Base/Input/type.ts
+++ b/src/Components/Base/Input/type.ts
@@ -3,7 +3,6 @@ import { HTMLAttributes, InputHTMLAttributes } from 'react';
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   initialFocus?: boolean;
-  invalid?: boolean;
   block?: boolean;
   errorMessage?: string;
   wrapperProps?: HTMLAttributes<HTMLDivElement>;

--- a/src/Components/Base/Input/type.ts
+++ b/src/Components/Base/Input/type.ts
@@ -5,7 +5,7 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
   initialFocus?: boolean;
   invalid?: boolean;
   block?: boolean;
+  errorMessage?: string;
   wrapperProps?: HTMLAttributes<HTMLDivElement>;
 }
-
 export default Props;


### PR DESCRIPTION
## ✨ 반영 브랜치
`feature/inputComponent` -> `dev`

## 📝 설명
input 컴포넌트에서 에러 메세지를 받아 UI에 보여주는 기능을 추가
props에 errorMesasge가 추가되고 선택적으로 받을 수 있습니다. 일단 색상과 사이즈를 고정으로 설정했습니다.


## ✅ 변경 사항
- [x] Input/lindex.tsx에 props로 errorMessage 추가
- [x] Input/type.ts에 errorMessage 타입 추가
- [x] Input/style.ts에 errorMessage 스타일 컴포넌트 추가

## 💬 PR 포인트 & 질문사항
- form 작업하면서 input 컴포넌트 내부에서 한 번에 처리하면 좋을 것 같다고 생각해서 추가했는데 다들 괜찮으실까요?

## ✅ 피드백 반영
- [x] invalid props 제거하고 errorMessage props로 에러를 모두 처리


