### PR TITLE
Feat: useClickAway 커스텀 훅 기능 개발

### DIFF
--- a/src/Hooks/UseClickAway/index.ts
+++ b/src/Hooks/UseClickAway/index.ts
@@ -1,0 +1,41 @@
+/* eslint-disable consistent-return */
+import { useEffect, useRef } from 'react';
+
+// 모바일 환경을 고려하여 touchstart를 추가한다.
+const events = ['mousedown', 'touchstart'];
+
+const useClickAway = (handler: (e: Event) => void) => {
+  const ref = useRef(null);
+  const savedHandler = useRef(handler);
+
+  // handler함수가 바뀌면 저장한다.
+  useEffect(() => {
+    savedHandler.current = handler;
+  }, [handler]);
+
+  useEffect(() => {
+    const element = ref.current as HTMLElement | null;
+    if (!element) return;
+
+    const handleEvent = (e: Event) => {
+      if (element.contains(e.target as Node)) {
+        return;
+      }
+      savedHandler.current(e);
+    };
+
+    events.forEach((eventName) => {
+      document.addEventListener(eventName, handleEvent);
+    });
+
+    return () => {
+      events.forEach((eventName) => {
+        document.removeEventListener(eventName, handleEvent);
+      });
+    };
+  }, [ref]);
+
+  return ref;
+};
+
+export default useClickAway;

--- a/src/Hooks/index.ts
+++ b/src/Hooks/index.ts
@@ -1,2 +1,3 @@
 /* eslint-disable import/prefer-default-export */
 export { default as useForm } from './UseForm';
+export { default as UseClickAway } from './UseClickAway';


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/useClickAway` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
지정한 컴포넌트의 바깥을 클릭하면 지정한 핸들러 함수가 실행 되도록 하는 커스텀 훅 입니다.

### 사용 예시

![useClickAway-Test](https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/assets/78135416/69044462-f710-4d68-8eb2-510397ee05e4)

```jsx
const [isShow, setIsShow] = useState(false);
  // 바깥을 클릭했을 때 실행될 함수를 전달한다.
  const ref = useClickAway(() => {
    setIsShow(false);
  };);
  ...
  <button 
      ref={ref} 
      onClick={()=>setIsShow(true)}
  >테스트 버튼</button>
  {isShow && <div>보이나요?</div>}

```

이런식으로 사용하시면 됩니다.


<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] Hooks/UseClickAway에 코드 작성
- [x] Hooks/index.ts에 barrel export 추가

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 타입스크립트 관련 고민을 많이 하며 만들었는데(너무 빨간줄이 많이 나서...), 그냥 useRef에는 타입을 지정하지 않고, useEffect 내부에서 `타입 단언` 과 `타입 가드` 를 통해 구현하게 되었습니다. `useRef<HTMLElement>` 로 지정하니 Legacy, Mutable 이런 세세한 속성까지 맞지 않는다고 자꾸 뭐라 하네요.😭 `useRef<HTMLButtonElement>` 이런식으로 세세하게 지정해주면 오히려 오류는 안나는데, 그러면 재사용에 문제가 생겨서 그냥 useRef에는 타입을 지정하지 않게 되었습니다!
- 그리고 useEffect return 에는 화살표 함수를 사용해야하는데 eslint에서 막아서 이 부분 주석 처리 했습니다. 
- 기타 궁금하신 점 있으시면 질문 주세요!

