### PR TITLE
Feat: ImageUpload 컴포넌트 구현

### DIFF
--- a/src/Components/Common/ImageUpload/index.tsx
+++ b/src/Components/Common/ImageUpload/index.tsx
@@ -1,21 +1,26 @@
 import { ChangeEvent, MouseEvent, useMemo, useRef, useState } from 'react';
-import Icon from '@/Components/Base/Icon';
+import { useTheme } from 'styled-components';
 import {
   StyledImage,
-  StyledInput,
   StyledText,
   StyledWrapper,
   StyledUploadForm,
-  StyledButton,
   IconStyle,
+  getButtonStyle,
 } from './style';
 import { ImageFileType, ImageUploadProps } from './type';
+import Icon from '@/Components/Base/Icon';
 import Button from '@/Components/Base/Button';
 import Input from '@/Components/Base/Input';
 
 const ImageUpload = ({ width, height, fontSize }: ImageUploadProps) => {
   const uploadInput = useRef<HTMLInputElement>(null);
   const [imageFile, setImageFile] = useState<ImageFileType | null>(null);
+
+  const { colors } = useTheme();
+  const getButtonBgColor = colors.buttonBackground;
+  const getButtonTextColor = colors.buttonText;
+  const getButtonhoverBgColor = colors.buttonClickHover;
 
   /**
    * 파일 업로드 버튼 클릭 핸들러 함수
@@ -73,13 +78,22 @@ const ImageUpload = ({ width, height, fontSize }: ImageUploadProps) => {
           style={{ fontSize: fontSize && fontSize * 50, ...IconStyle }}
         />
         <StyledText>사진을 선택하여 추가해주세요.</StyledText>
-        <Button onClick={handleClickUpload}>가져오기</Button>
-        {/* <StyledButton onClick={handleClickUpload}>가져오기</StyledButton> */}
-        <StyledInput
+        <Button
+          borderRadius="1rem"
+          backgroundColor={getButtonBgColor}
+          hoverBackgroundColor={getButtonhoverBgColor}
+          textColor={getButtonTextColor}
+          onClick={handleClickUpload}
+          style={getButtonStyle}
+        >
+          가져오기
+        </Button>
+        <Input
           type="file"
           accept="image/*"
           ref={uploadInput}
           onChange={uploadImage}
+          style={{ display: 'none' }}
         />
       </StyledUploadForm>
     </StyledWrapper>

--- a/src/Components/Common/ImageUpload/index.tsx
+++ b/src/Components/Common/ImageUpload/index.tsx
@@ -10,6 +10,8 @@ import {
   IconStyle,
 } from './style';
 import { ImageFileType, ImageUploadProps } from './type';
+import Button from '@/Components/Base/Button';
+import Input from '@/Components/Base/Input';
 
 const ImageUpload = ({ width, height, fontSize }: ImageUploadProps) => {
   const uploadInput = useRef<HTMLInputElement>(null);
@@ -21,7 +23,6 @@ const ImageUpload = ({ width, height, fontSize }: ImageUploadProps) => {
    */
   const handleClickUpload = (e: MouseEvent) => {
     e.preventDefault();
-
     uploadInput.current?.click();
   };
 
@@ -72,9 +73,8 @@ const ImageUpload = ({ width, height, fontSize }: ImageUploadProps) => {
           style={{ fontSize: fontSize && fontSize * 50, ...IconStyle }}
         />
         <StyledText>사진을 선택하여 추가해주세요.</StyledText>
-        {/* 버튼 컴포넌트 handleClick에 e.preventDefault 필요 */}
-        {/* <Button onClickButton={handleClickUpload}>가져오기</Button> */}
-        <StyledButton onClick={handleClickUpload}>가져오기</StyledButton>
+        <Button onClick={handleClickUpload}>가져오기</Button>
+        {/* <StyledButton onClick={handleClickUpload}>가져오기</StyledButton> */}
         <StyledInput
           type="file"
           accept="image/*"

--- a/src/Components/Common/ImageUpload/index.tsx
+++ b/src/Components/Common/ImageUpload/index.tsx
@@ -1,24 +1,87 @@
-import { useRef } from 'react';
+import { ChangeEvent, MouseEvent, useMemo, useRef, useState } from 'react';
 import Icon from '@/Components/Base/Icon';
-import { StyledInput, StyledText, StyledWrapper } from './style';
-import Button from '@/Components/Base/Button';
+import {
+  StyledImage,
+  StyledInput,
+  StyledText,
+  StyledWrapper,
+  StyledUploadForm,
+  StyledButton,
+  IconStyle,
+} from './style';
+import { ImageFileType, ImageUploadProps } from './type';
 
-const ImageUpload = () => {
+const ImageUpload = ({ width, height, fontSize }: ImageUploadProps) => {
   const uploadInput = useRef<HTMLInputElement>(null);
+  const [imageFile, setImageFile] = useState<ImageFileType | null>(null);
+
+  /**
+   * 파일 업로드 버튼 클릭 핸들러 함수
+   * 다른 요소에서 클릭 이벤트에 매핑하면 파일 업로드 진행됨
+   */
+  const handleClickUpload = (e: MouseEvent) => {
+    e.preventDefault();
+
+    uploadInput.current?.click();
+  };
+
+  /**
+   * 업로드 이미지 파일 상태로 저장하는 함수
+   * 파일의 url을 URL.createObjectURL로 변환하여 저장
+   */
+  const uploadImage = (e: ChangeEvent<HTMLInputElement>) => {
+    const ImageFileData = e.target.files;
+    const isFileEmpty = ImageFileData?.length === 0;
+
+    if (ImageFileData && !isFileEmpty) {
+      const uploadImageUrl = URL.createObjectURL(ImageFileData[0]);
+
+      setImageFile({
+        file: ImageFileData[0],
+        imageUrl: uploadImageUrl,
+        type: ImageFileData[0].type.slice(0, 5),
+      });
+    }
+  };
+
+  /**
+   * 업로드한 이미지가 있는지에 따라 업로드 폼과 이미지를 교체하는 함수
+   * useMemo를 사용한 것은 이미지 업로드와 렌더링을 최적화하기 위함
+   */
+  const showUploadImage = useMemo(() => {
+    return imageFile ? (
+      <StyledImage
+        src={imageFile.imageUrl}
+        alt={imageFile.type}
+        onClick={handleClickUpload}
+      />
+    ) : null;
+  }, [imageFile]);
 
   return (
-    <StyledWrapper>
-      <Icon
-        name="add_a_photo"
-        onClick={() => console.log('icon 클릭')}
-      />
-      <StyledText>사진을 선택하여 추가해주세요.</StyledText>
-      <Button onClickButton={() => console.log('button 클릭')}>가져오기</Button>
-      <StyledInput
-        type="file"
-        accept="image/*"
-        ref={uploadInput}
-      />
+    <StyledWrapper
+      $width={width}
+      $height={height}
+      $fontSize={fontSize}
+    >
+      {showUploadImage}
+      <StyledUploadForm style={{ display: imageFile ? 'none' : 'flex' }}>
+        <Icon
+          name="add_a_photo"
+          onClick={handleClickUpload}
+          style={{ fontSize: fontSize && fontSize * 50, ...IconStyle }}
+        />
+        <StyledText>사진을 선택하여 추가해주세요.</StyledText>
+        {/* 버튼 컴포넌트 handleClick에 e.preventDefault 필요 */}
+        {/* <Button onClickButton={handleClickUpload}>가져오기</Button> */}
+        <StyledButton onClick={handleClickUpload}>가져오기</StyledButton>
+        <StyledInput
+          type="file"
+          accept="image/*"
+          ref={uploadInput}
+          onChange={uploadImage}
+        />
+      </StyledUploadForm>
     </StyledWrapper>
   );
 };

--- a/src/Components/Common/ImageUpload/index.tsx
+++ b/src/Components/Common/ImageUpload/index.tsx
@@ -1,0 +1,26 @@
+import { useRef } from 'react';
+import Icon from '@/Components/Base/Icon';
+import { StyledInput, StyledText, StyledWrapper } from './style';
+import Button from '@/Components/Base/Button';
+
+const ImageUpload = () => {
+  const uploadInput = useRef<HTMLInputElement>(null);
+
+  return (
+    <StyledWrapper>
+      <Icon
+        name="add_a_photo"
+        onClick={() => console.log('icon 클릭')}
+      />
+      <StyledText>사진을 선택하여 추가해주세요.</StyledText>
+      <Button onClickButton={() => console.log('button 클릭')}>가져오기</Button>
+      <StyledInput
+        type="file"
+        accept="image/*"
+        ref={uploadInput}
+      />
+    </StyledWrapper>
+  );
+};
+
+export default ImageUpload;

--- a/src/Components/Common/ImageUpload/style.ts
+++ b/src/Components/Common/ImageUpload/style.ts
@@ -28,21 +28,10 @@ export const StyledText = styled.p`
   user-select: none;
 `;
 
-export const StyledButton = styled.button`
-  padding: 1rem 2rem;
-  border-radius: 1rem;
-  color: ${({ theme }) => theme.colors.buttonText};
-  background-color: ${({ theme }) => theme.colors.buttonBackground};
-  transition: background-color 50ms ease-in-out;
-
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.buttonClickHover};
-  }
-`;
-
-export const StyledInput = styled.input`
-  display: none;
-`;
+export const getButtonStyle = {
+  padding: '1rem 2rem',
+  transition: 'background-color 50ms ease-in-out',
+};
 
 export const StyledImage = styled.img`
   object-fit: contain;

--- a/src/Components/Common/ImageUpload/style.ts
+++ b/src/Components/Common/ImageUpload/style.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const StyledText = styled.p``;
+export const StyledInput = styled.input``;

--- a/src/Components/Common/ImageUpload/style.ts
+++ b/src/Components/Common/ImageUpload/style.ts
@@ -1,10 +1,54 @@
 import styled from 'styled-components';
 
-export const StyledWrapper = styled.div`
+export const StyledWrapper = styled.div<{
+  $width: string;
+  $height: string;
+  $fontSize?: number;
+}>`
+  // 영역 표시 위해 남겨둠 필요 시 배경색 재설정
+  background-color: ${({ theme }) => theme.colors.background};
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  width: ${(props) => props.$width};
+  height: ${(props) => props.$height};
+  font-size: ${(props) => props.$fontSize}rem;
 `;
 
-export const StyledText = styled.p``;
-export const StyledInput = styled.input``;
+export const StyledUploadForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+`;
+
+export const StyledText = styled.p`
+  font-weight: 600;
+  user-select: none;
+`;
+
+export const StyledButton = styled.button`
+  padding: 1rem 2rem;
+  border-radius: 1rem;
+  color: ${({ theme }) => theme.colors.buttonText};
+  background-color: ${({ theme }) => theme.colors.buttonBackground};
+  transition: background-color 50ms ease-in-out;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.buttonClickHover};
+  }
+`;
+
+export const StyledInput = styled.input`
+  display: none;
+`;
+
+export const StyledImage = styled.img`
+  object-fit: contain;
+  cursor: pointer;
+`;
+
+export const IconStyle = {
+  cursor: 'pointer',
+};

--- a/src/Components/Common/ImageUpload/type.ts
+++ b/src/Components/Common/ImageUpload/type.ts
@@ -1,0 +1,13 @@
+import { HTMLAttributes } from 'react';
+
+export interface ImageUploadProps extends HTMLAttributes<HTMLDivElement> {
+  width: string;
+  height: string;
+  fontSize?: number;
+}
+
+export interface ImageFileType {
+  file: File;
+  imageUrl: string;
+  type: string;
+}

--- a/src/Pages/HomePage/index.tsx
+++ b/src/Pages/HomePage/index.tsx
@@ -1,10 +1,16 @@
 import { Link } from 'react-router-dom';
+import ImageUpload from '@/Components/Common/ImageUpload';
 
 const HomePage = () => {
   return (
     <>
       <div>HomePage</div>
       <Link to="/detail">Detail</Link>
+      <ImageUpload
+        width="50rem"
+        height="50rem"
+        fontSize={2}
+      />
     </>
   );
 };


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/imageUpload` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
![imageUpload](https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/assets/70748442/ad330fab-72b7-4e4d-a119-4ce45de7d44b)

## 📝 설명
사진을 업로드할 수 있는 공용 컴포넌트를 구현했습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] width, height, fontSize를 props를 받아서 ImageUpload 컴포넌트의 크기와 내부 폰트 크기를 조절 가능합니다.
- [x]  `handleClickUpload`, `uploadImage` 함수를 통해 클릭 시 업로드 로직이 가능하도록 구현했습니다.
- [x] 이미지 표시 로직 `showUploadImage`를 useMemo를 통해 업로드 로직과 렌더링을 최적화해보았습니다.
- [x] Input, Button 공통 컴포넌트를 사용해서 내부를 구현했습니다.

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 추가적으로 props로 넘겨줄 만한 것이 있다면 알려주세요!


