### PR TITLE
Feat: Input 컴포넌트 ref 기능 추가

### DIFF
--- a/src/Components/Base/Input/index.tsx
+++ b/src/Components/Base/Input/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { ForwardedRef, forwardRef } from 'react';
 import {
   StyledWrapper,
   StyledInput,
@@ -8,39 +8,32 @@ import {
 } from './style';
 import Props from './type';
 
-const Input = ({
-  label,
-  initialFocus = false,
-  block = false,
-  wrapperProps,
-  errorMessage,
-  ...props
-}: Props) => {
-  const inputRef = useRef<HTMLInputElement>(null);
+const Input = forwardRef(
+  (
+    { label, block = false, wrapperProps, errorMessage, ...props }: Props,
+    ref: ForwardedRef<HTMLInputElement>,
+  ) => {
+    return (
+      <StyledWrapper
+        $block={block}
+        {...wrapperProps}
+      >
+        <StyledContainer>
+          {label && <StyledLabel>{label}</StyledLabel>}
+          {errorMessage && (
+            <StyledErrorMessage>{errorMessage}</StyledErrorMessage>
+          )}
+        </StyledContainer>
+        <StyledInput
+          $invalid={!!errorMessage}
+          ref={ref}
+          {...props}
+        />
+      </StyledWrapper>
+    );
+  },
+);
 
-  useEffect(() => {
-    if (initialFocus && inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, [initialFocus]);
+Input.displayName = 'Input';
 
-  return (
-    <StyledWrapper
-      $block={block}
-      {...wrapperProps}
-    >
-      <StyledContainer>
-        {label && <StyledLabel>{label}</StyledLabel>}
-        {errorMessage && (
-          <StyledErrorMessage>{errorMessage}</StyledErrorMessage>
-        )}
-      </StyledContainer>
-      <StyledInput
-        $invalid={!!errorMessage}
-        ref={inputRef}
-        {...props}
-      />
-    </StyledWrapper>
-  );
-};
 export default Input;

--- a/src/Components/Base/Input/type.ts
+++ b/src/Components/Base/Input/type.ts
@@ -2,9 +2,9 @@ import { HTMLAttributes, InputHTMLAttributes } from 'react';
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
-  initialFocus?: boolean;
   block?: boolean;
   errorMessage?: string;
   wrapperProps?: HTMLAttributes<HTMLDivElement>;
 }
+
 export default Props;


### PR DESCRIPTION
## ✨ 반영 브랜치
`feature/InputComponentRef` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
- forwardRef를 사용해 상위 컴포넌트에서 input 태그를 ref로 참조할 수 있게 기능을 추가했습니다.

## ✅ 변경 사항
- [x] ref 속성을 상위에서 사용할 수 있기에 내부 ref를 활용한 초기 focus 로직은 제거 했습니다.
- [x] props의 initialFocus 속성도 삭제했습니다. 

## 💬 PR 포인트 & 질문사항