### PR TITLE
Fix: Button 컴포넌트 ref 및 클릭이벤트 props 수정

### DIFF
--- a/src/Components/Base/Button/index.tsx
+++ b/src/Components/Base/Button/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { ForwardedRef, forwardRef } from 'react';
 import StyledButton from './style';
 import type { ButtonProp } from './type';
 
@@ -7,49 +7,39 @@ import type { ButtonProp } from './type';
  * style={{ padding: '10px 20px' }} 과 같이 프롭스에 없는 스타일을 부여해줄 수 있습니다.
  */
 
-const Button = ({
-  children,
-  backgroundColor = 'default',
-  textColor = 'default',
-  textSize = 'default',
-  width = 'default',
-  height = 'default',
-  borderRadius = 'default',
-  isToggleButton = false,
-  onClickButton,
-  style,
-}: ButtonProp) => {
-  const [isActive, setIsActive] = useState(false);
+const Button = forwardRef(
+  (
+    {
+      children,
+      backgroundColor = 'default',
+      textColor = 'default',
+      textSize = 'default',
+      width = 'default',
+      height = 'default',
+      borderRadius = 'default',
+      isActive,
+      ...props
+    }: ButtonProp,
+    ref: ForwardedRef<HTMLButtonElement>,
+  ) => {
+    return (
+      <StyledButton
+        $backgroundColor={backgroundColor}
+        $textColor={textColor}
+        $textSize={textSize}
+        $width={width}
+        $height={height}
+        $borderRadius={borderRadius}
+        $isActive={isActive}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </StyledButton>
+    );
+  },
+);
 
-  const handleClick = () => {
-    if (onClickButton) {
-      onClickButton();
-    }
-  };
-
-  const handleToggle = () => {
-    setIsActive(!isActive);
-
-    if (onClickButton) {
-      onClickButton(isActive);
-    }
-  };
-
-  return (
-    <StyledButton
-      onClick={isToggleButton ? handleToggle : handleClick}
-      $backgroundColor={backgroundColor}
-      $textColor={textColor}
-      $textSize={textSize}
-      $width={width}
-      $height={height}
-      $borderRadius={borderRadius}
-      $isActive={isActive}
-      style={{ ...style }}
-    >
-      {children}
-    </StyledButton>
-  );
-};
+Button.displayName = 'Button';
 
 export default Button;

--- a/src/Components/Base/Button/type.ts
+++ b/src/Components/Base/Button/type.ts
@@ -7,10 +7,7 @@ export interface ButtonProp extends ButtonHTMLAttributes<HTMLButtonElement> {
   width?: 'default' | string;
   height?: 'default' | string;
   borderRadius?: 'default' | string;
-  isToggleButton?: 'default' | boolean;
-
-  onClickButton?: (active?: boolean) => void;
-  style?: React.CSSProperties;
+  isActive?: boolean;
 }
 
 export interface StyledButtonProp
@@ -21,5 +18,5 @@ export interface StyledButtonProp
   $width: string;
   $height: string;
   $borderRadius: string;
-  $isActive: boolean;
+  $isActive?: boolean;
 }


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/fixButtonComponent` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
Button 공용 컴포넌트에서 ref와 클릭이벤트 관련 props 로직 및 타입을 수정했습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] ref props를 위해 forwardRef를 사용해서 구현했습니다.
- [x] 클릭이벤트에 대한 이벤트를 컴포넌트 외부에서 핸들링 할 수 있도록 `...props`로 받도록 변경했습니다. 

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 추후에 ref나 토글이벤트가 문제 있을 경우 문의주세요!
- Button 컴포넌트 테스트 코드입니다. (Pages/Homepage/index.tsx)
```js
import { Link } from 'react-router-dom';
import { useEffect, useRef } from 'react';
import Button from '@/Components/Base/Button';

const HomePage = () => {
  const btnRef = useRef<HTMLButtonElement>(null);

  useEffect(() => {
    console.log(btnRef.current);
  }, [btnRef]);
  return (
    <>
      <div>HomePage</div>
      <Link to="/detail">Detail</Link>
      <Button
        ref={btnRef}
        onClick={() => console.log('클릭')}
      >
        가져오기
      </Button>
    </>
  );
};

export default HomePage;

```

![image](https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/assets/70748442/04057291-0542-42da-88dd-50de925b1c59)


