### PR TITLE
Feat: Badge 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,17 +2,12 @@ import { ThemeProvider } from 'styled-components';
 import { lightTheme } from '@/Styles/Theme';
 import GlobalStyle from '@/Styles/Global';
 import RouteManager from '@/Routes/Router';
-import Avatar from './Components/Base/Avatar';
-import Badge from './Components/Base/Badge';
 
 const App = () => {
   return (
     <ThemeProvider theme={lightTheme}>
       <GlobalStyle />
       <RouteManager />
-      <Avatar>
-        <Badge>144</Badge>
-      </Avatar>
     </ThemeProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,17 @@ import { ThemeProvider } from 'styled-components';
 import { lightTheme } from '@/Styles/Theme';
 import GlobalStyle from '@/Styles/Global';
 import RouteManager from '@/Routes/Router';
+import Avatar from './Components/Base/Avatar';
+import Badge from './Components/Base/Badge';
 
 const App = () => {
   return (
     <ThemeProvider theme={lightTheme}>
       <GlobalStyle />
       <RouteManager />
+      <Avatar>
+        <Badge>144</Badge>
+      </Avatar>
     </ThemeProvider>
   );
 };

--- a/src/Components/Base/Avatar/index.tsx
+++ b/src/Components/Base/Avatar/index.tsx
@@ -1,6 +1,6 @@
 import { ForwardedRef, forwardRef } from 'react';
 import { AvatarProp } from './type';
-import { StyledAvatarWrapper, StyledAvatar } from './style';
+import { StyledImage, StyledAvatar, StyledWrapper } from './style';
 
 const Avatar = forwardRef(
   (
@@ -12,25 +12,31 @@ const Avatar = forwardRef(
       shape = 'circle',
       mode = 'cover',
       wrapperProps,
+      containerProps,
       ...props
     }: AvatarProp,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
     return (
-      <StyledAvatarWrapper
-        $shape={shape}
+      <StyledWrapper
+        $size={size}
         ref={ref}
         {...wrapperProps}
       >
         <StyledAvatar
-          src={src || `https://via.placeholder.com/${size}.jpg`}
-          alt={alt}
-          $size={size}
-          $mode={mode}
-          {...props}
-        />
+          $shape={shape}
+          {...containerProps}
+        >
+          <StyledImage
+            src={src || `https://via.placeholder.com/${size}.jpg`}
+            alt={alt}
+            $size={size}
+            $mode={mode}
+            {...props}
+          />
+        </StyledAvatar>
         {children}
-      </StyledAvatarWrapper>
+      </StyledWrapper>
     );
   },
 );

--- a/src/Components/Base/Avatar/style.ts
+++ b/src/Components/Base/Avatar/style.ts
@@ -1,11 +1,21 @@
 import styled from 'styled-components';
-import { StyledAvatarWrapperProp, StyledAvatarProp } from './type';
+import { StyledWrapperProp, StyledImageProp, StyledAvatarProp } from './type';
 
-export const StyledAvatarWrapper = styled.div<StyledAvatarWrapperProp>`
+export const StyledWrapper = styled.div<StyledWrapperProp>`
   position: relative;
+  ${({ $size }) => `
+    width: ${$size}px;
+    height: ${$size}px;
+  `}
+`;
+
+export const StyledAvatar = styled.div<StyledAvatarProp>`
   display: inline-block;
   overflow: hidden;
+  width: 100%;
+  height: 100%;
 
+  box-sizing: border-box;
   border: 1px solid
     ${({ theme }) => `
       ${theme.colors.border}
@@ -18,11 +28,9 @@ export const StyledAvatarWrapper = styled.div<StyledAvatarWrapperProp>`
     })[$shape || 'square']};
 `;
 
-export const StyledAvatar = styled.img<StyledAvatarProp>`
+export const StyledImage = styled.img<StyledImageProp>`
   display: block;
-  ${({ $size, $mode }) => `
-    width: ${$size}px;
-    height: ${$size}px;
-    object-fit: ${$mode}
-  `}
+  ${({ $mode }) => `object-fit: ${$mode}`};
+  width: 100%;
+  height: 100%;
 `;

--- a/src/Components/Base/Avatar/type.ts
+++ b/src/Components/Base/Avatar/type.ts
@@ -7,14 +7,18 @@ export interface AvatarProp extends HTMLAttributes<HTMLDivElement> {
   shape?: 'circle' | 'round' | 'square';
   mode?: 'cover' | 'contain' | 'fill';
   wrapperProps?: HTMLAttributes<HTMLDivElement>;
+  containerProps?: HTMLAttributes<HTMLDivElement>;
 }
 
-export interface StyledAvatarWrapperProp
-  extends HTMLAttributes<HTMLDivElement> {
+export interface StyledWrapperProp extends HTMLAttributes<HTMLDivElement> {
+  $size: number;
+}
+
+export interface StyledAvatarProp extends HTMLAttributes<HTMLDivElement> {
   $shape: string;
 }
 
-export interface StyledAvatarProp extends ImgHTMLAttributes<HTMLImageElement> {
+export interface StyledImageProp extends ImgHTMLAttributes<HTMLImageElement> {
   $size: number;
   $mode: string;
 }

--- a/src/Components/Base/Badge/index.tsx
+++ b/src/Components/Base/Badge/index.tsx
@@ -1,0 +1,48 @@
+import { ForwardedRef, forwardRef } from 'react';
+import { useTheme } from 'styled-components';
+import StyledBadge from './style';
+import { BadgeProp } from './type';
+
+/**
+ * Badge 컴포넌트를 사용하는 상위 요소의 position: relative 속성을 확인해주세요
+ */
+const Badge = forwardRef(
+  (
+    {
+      children,
+      size,
+      position,
+      backgroundColor,
+      textColor,
+      textSize,
+      ...props
+    }: BadgeProp,
+    ref: ForwardedRef<HTMLSpanElement>,
+  ) => {
+    const theme = useTheme();
+
+    const isSingleDigit =
+      String(children).length <= 2 || children === undefined;
+    const shape = isSingleDigit ? 'circle' : 'ellipse';
+    const isOverDigit = Number(children) >= 99;
+
+    return (
+      <StyledBadge
+        ref={ref}
+        $size={size || '0.8rem'}
+        $position={position || 'rightTop'}
+        $backgroundColor={backgroundColor || theme.colors.alert}
+        $textColor={textColor || theme.colors.buttonText}
+        $textSize={textSize || '0.4rem'}
+        $shape={shape}
+        {...props}
+      >
+        {isOverDigit ? '99+' : children}
+      </StyledBadge>
+    );
+  },
+);
+
+Badge.displayName = 'Badge';
+
+export default Badge;

--- a/src/Components/Base/Badge/index.tsx
+++ b/src/Components/Base/Badge/index.tsx
@@ -5,12 +5,13 @@ import { BadgeProp } from './type';
 
 /**
  * Badge 컴포넌트를 사용하는 상위 요소의 position: relative 속성을 확인해주세요
+ * @param size: px, rem 단위를 포함한 문자열 형태로 전달해주세요
  */
 const Badge = forwardRef(
   (
     {
       children,
-      size,
+      size = '0.8rem',
       position,
       backgroundColor,
       textColor,
@@ -26,14 +27,17 @@ const Badge = forwardRef(
     const shape = isSingleDigit ? 'circle' : 'ellipse';
     const isOverDigit = Number(children) >= 99;
 
+    const parsedSize = parseFloat(size);
+    const halfSize = Number.isNaN(parsedSize) ? size : `${parsedSize / 2}rem`;
+
     return (
       <StyledBadge
         ref={ref}
-        $size={size || '0.8rem'}
+        $size={size}
         $position={position || 'rightTop'}
         $backgroundColor={backgroundColor || theme.colors.alert}
         $textColor={textColor || theme.colors.buttonText}
-        $textSize={textSize || '0.4rem'}
+        $textSize={textSize || halfSize}
         $shape={shape}
         {...props}
       >

--- a/src/Components/Base/Badge/style.ts
+++ b/src/Components/Base/Badge/style.ts
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+import { StyledBadgeProp } from './type';
+
+const StyledBadge = styled.span<StyledBadgeProp>`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.1rem 0.2rem;
+  font-size: ${({ $textSize }) => $textSize};
+
+  ${({ $position }) =>
+    ({
+      leftTop: 'top: 0px; left: 0px;',
+      leftBottom: 'bottom: 0px; left: 0px;',
+      rightTop: 'top: 0px; right: 0px;',
+      rightBottom: 'bottom: 0px; right: 0px;',
+    })[$position]};
+
+  ${({ $shape, $size }) =>
+    ({
+      circle: `
+        width: ${$size};
+        height: ${$size};
+        border-radius: 50%;`,
+      ellipse: `
+        width: auto;
+        height: auto;
+        border-radius: 45%;`,
+    })[$shape]}
+
+  background-color: ${({ $backgroundColor }) => $backgroundColor};
+  color: ${({ $textColor }) => $textColor};
+`;
+
+export default StyledBadge;

--- a/src/Components/Base/Badge/style.ts
+++ b/src/Components/Base/Badge/style.ts
@@ -24,8 +24,8 @@ const StyledBadge = styled.span<StyledBadgeProp>`
         height: ${$size};
         border-radius: 50%;`,
       ellipse: `
-        width: auto;
-        height: auto;
+        width: calc(${$size} * 1.3)rem;;
+        height: ${$size}rem;
         border-radius: 45%;`,
     })[$shape]}
 

--- a/src/Components/Base/Badge/type.ts
+++ b/src/Components/Base/Badge/type.ts
@@ -1,0 +1,18 @@
+import { HTMLAttributes } from 'react';
+
+export interface BadgeProp extends HTMLAttributes<HTMLSpanElement> {
+  size?: string;
+  position: 'leftTop' | 'leftBottom' | 'rightTop' | 'rightBottom';
+  backgroundColor?: string;
+  textColor?: string;
+  textSize?: string;
+}
+
+export interface StyledBadgeProp extends HTMLAttributes<HTMLSpanElement> {
+  $size: string;
+  $position: 'leftTop' | 'leftBottom' | 'rightTop' | 'rightBottom';
+  $backgroundColor: string;
+  $textColor: string;
+  $textSize: string;
+  $shape: string;
+}


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/badgeComponent` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
알림, 접속 중임을 알리는 Badge 컴포넌트입니다.


1. 부착을 원하는 요소에 children을 통해 Badge 컴포넌트를 내려주시고, `position: relative`로 설정해주세요.
2. `children`을 내려주지 않거나, 한 글자인 경우 원형을 유지하도록 하였습니다. 이외의 경우에는 내려주는 children에 따라 크기가 확장됩니다.
3. 99개 이상의 알림이 오는 경우 99+로 고정하여 출력하도록 하였습니다.
4. Badge의 `position`은 각 모서리 4방향을 `'leftTop'` | `'leftBottom'` | `'rightTop'` | `'rightBottom'` 프롭으로 지정 가능하게 하였습니다. 기본값은 `'rightTop'`입니다.


<img width="200" alt="스크린샷 2024-01-02 오후 7 47 42" src="https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/assets/95916813/da10bc07-0ba6-4f3c-9ad8-3a5bfc455783">


<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- 타입, 스타일 컴포넌트, index 구현
- Avatar 컴포넌트 wrapper 추가, 내부 컴포넌트에 크기를 상속하도록 함 

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- Prop과 초기값, 단위 관련하여 개선사항이 있다면 피드백 주시면 감사하겠습니다.
- Badge 컴포넌트와의 호환을 위하여 Avatar 컴포넌트도 수정하였으니, 참고 부탁드립니다. (wrapper, 크기 상속 등)
