### PR TITLE
Feat: DropDown 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { lightTheme } from '@/Styles/Theme';
 import GlobalStyle from '@/Styles/Global';
 import RouteManager from '@/Routes/Router';
-import DropDown from './Components/Common/DropDown';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -12,21 +11,11 @@ const queryClient = new QueryClient({
 });
 
 const App = () => {
-  const handleSelect = (option: string) => {
-    console.log(option);
-  };
-
   return (
     <ThemeProvider theme={lightTheme}>
       <QueryClientProvider client={queryClient}>
         <GlobalStyle />
         <RouteManager />
-
-        {/* 테스트코드 */}
-        <DropDown
-          options={['전체', '클래식', '스트릿']}
-          onSelect={handleSelect}
-        />
       </QueryClientProvider>
     </ThemeProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { lightTheme } from '@/Styles/Theme';
 import GlobalStyle from '@/Styles/Global';
 import RouteManager from '@/Routes/Router';
+import DropDown from './Components/Common/DropDown';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -11,11 +12,21 @@ const queryClient = new QueryClient({
 });
 
 const App = () => {
+  const handleSelect = (option: string) => {
+    console.log(option);
+  };
+
   return (
     <ThemeProvider theme={lightTheme}>
       <QueryClientProvider client={queryClient}>
         <GlobalStyle />
         <RouteManager />
+
+        {/* 테스트코드 */}
+        <DropDown
+          options={['전체', '클래식', '스트릿']}
+          onSelect={handleSelect}
+        />
       </QueryClientProvider>
     </ThemeProvider>
   );

--- a/src/Components/Common/DropDown/index.tsx
+++ b/src/Components/Common/DropDown/index.tsx
@@ -1,4 +1,5 @@
 import React, { ForwardedRef, forwardRef, useState } from 'react';
+import { useTheme } from 'styled-components';
 import type { DropDownProps } from './type';
 import {
   StyledDropDown,
@@ -11,6 +12,7 @@ import Icon from '@/Components/Base/Icon';
 const DropDown = forwardRef(
   (
     {
+      children,
       options,
       label,
       labelTextColor,
@@ -31,6 +33,7 @@ const DropDown = forwardRef(
     }: DropDownProps,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
+    const theme = useTheme();
     const [selectedOption, setSelectedOption] = useState('선택 없음');
     const [isOpen, setIsOpen] = useState(false);
 
@@ -58,25 +61,38 @@ const DropDown = forwardRef(
       >
         <StyledDropDownButton
           onClick={() => setIsOpen(!isOpen)}
+          $width={width || '160px'}
+          $height={height || '40px'}
+          $backgroundColor={backgroundColor || theme.colors.background}
+          $textColor={textColor || theme.colors.text}
+          $textSize={textSize || theme.size.medium}
           {...buttonProps}
         >
           {selectedOption}
           <Icon
-            name="cancel"
-            isFill={false}
+            name={
+              selectedOption === '선택 없음' ? 'expand_circle_down' : 'cancel'
+            }
+            isFill
             onClick={handleCancel}
             style={{ color: textColor }}
           />
         </StyledDropDownButton>
         {isOpen && (
           <StyledDropDownOption
-            $size={width || '160px'}
+            $width={width || '160px'}
             {...optionProps}
           >
             {options.map((option) => (
               <StyledDropDownItem
                 key={option}
                 onClick={() => handleSelect(option)}
+                $itemBackgroundColor={
+                  itemBackgroundColor || theme.colors.lightGray
+                }
+                $itemTextColor={itemTextColor || theme.colors.text}
+                $itemTextSize={itemTextSize || theme.size.small}
+                $width={width || '160px'}
                 {...itemProps}
               >
                 {option}

--- a/src/Components/Common/DropDown/index.tsx
+++ b/src/Components/Common/DropDown/index.tsx
@@ -1,0 +1,94 @@
+import React, { ForwardedRef, forwardRef, useState } from 'react';
+import type { DropDownProps } from './type';
+import {
+  StyledDropDown,
+  StyledDropDownButton,
+  StyledDropDownItem,
+  StyledDropDownOption,
+} from './style';
+import Icon from '@/Components/Base/Icon';
+
+const DropDown = forwardRef(
+  (
+    {
+      options,
+      label,
+      labelTextColor,
+      labelTextSize,
+      width,
+      height,
+      backgroundColor,
+      textColor,
+      textSize,
+      itemBackgroundColor,
+      itemTextColor,
+      itemTextSize,
+      onSelect,
+      buttonProps,
+      optionProps,
+      itemProps,
+      ...props
+    }: DropDownProps,
+    ref: ForwardedRef<HTMLDivElement>,
+  ) => {
+    const [selectedOption, setSelectedOption] = useState('선택 없음');
+    const [isOpen, setIsOpen] = useState(false);
+
+    const handleSelect = (option: string) => {
+      setSelectedOption(option);
+
+      if (onSelect) {
+        onSelect(option);
+      }
+
+      setIsOpen(false);
+    };
+
+    const handleCancel = (event: React.MouseEvent) => {
+      event.stopPropagation();
+      handleSelect('선택 없음');
+    };
+
+    return (
+      <StyledDropDown
+        ref={ref}
+        onMouseEnter={() => setIsOpen(true)}
+        onMouseLeave={() => setIsOpen(false)}
+        {...props}
+      >
+        <StyledDropDownButton
+          onClick={() => setIsOpen(!isOpen)}
+          {...buttonProps}
+        >
+          {selectedOption}
+          <Icon
+            name="cancel"
+            isFill={false}
+            onClick={handleCancel}
+            style={{ color: textColor }}
+          />
+        </StyledDropDownButton>
+        {isOpen && (
+          <StyledDropDownOption
+            $size={width || '160px'}
+            {...optionProps}
+          >
+            {options.map((option) => (
+              <StyledDropDownItem
+                key={option}
+                onClick={() => handleSelect(option)}
+                {...itemProps}
+              >
+                {option}
+              </StyledDropDownItem>
+            ))}
+          </StyledDropDownOption>
+        )}
+      </StyledDropDown>
+    );
+  },
+);
+
+DropDown.displayName = 'DropDown';
+
+export default DropDown;

--- a/src/Components/Common/DropDown/index.tsx
+++ b/src/Components/Common/DropDown/index.tsx
@@ -11,7 +11,7 @@ import {
 import Icon from '@/Components/Base/Icon';
 
 /**
- * @param options: 출력할 옵션들을 배열([])형태로 담아 전달해주세요. (필수)
+ * @param options 출력할 옵션들을 배열([])형태로 담아 전달해주세요. (필수)
  * 이 외의 프롭들은 선택적으로 전달해줄 수 있으며, px / rem 등의 단위가 포함된 String 형태로 전달해주세요.
  */
 

--- a/src/Components/Common/DropDown/index.tsx
+++ b/src/Components/Common/DropDown/index.tsx
@@ -6,6 +6,7 @@ import {
   StyledDropDownButton,
   StyledDropDownItem,
   StyledDropDownOption,
+  StyledLabel,
 } from './style';
 import Icon from '@/Components/Base/Icon';
 
@@ -29,6 +30,7 @@ const DropDown = forwardRef(
       buttonProps,
       optionProps,
       itemProps,
+      labelProps,
       ...props
     }: DropDownProps,
     ref: ForwardedRef<HTMLDivElement>,
@@ -39,11 +41,9 @@ const DropDown = forwardRef(
 
     const handleSelect = (option: string) => {
       setSelectedOption(option);
-
       if (onSelect) {
         onSelect(option);
       }
-
       setIsOpen(false);
     };
 
@@ -59,6 +59,16 @@ const DropDown = forwardRef(
         onMouseLeave={() => setIsOpen(false)}
         {...props}
       >
+        {label && (
+          <StyledLabel
+            $labelTextColor={labelTextColor || theme.colors.text}
+            $labelTextSize={labelTextSize || '1.2rem'}
+            $backgroundColor={backgroundColor || theme.colors.background}
+            {...labelProps}
+          >
+            {label}
+          </StyledLabel>
+        )}
         <StyledDropDownButton
           onClick={() => setIsOpen(!isOpen)}
           $width={width || '160px'}
@@ -69,15 +79,23 @@ const DropDown = forwardRef(
           {...buttonProps}
         >
           {selectedOption}
-          <Icon
-            name={
-              selectedOption === '선택 없음' ? 'expand_circle_down' : 'cancel'
-            }
-            isFill
-            onClick={handleCancel}
-            style={{ color: textColor }}
-          />
+          {selectedOption === '선택 없음' ? (
+            <Icon
+              name="expand_circle_down"
+              isFill
+              onClick={() => handleSelect(selectedOption)}
+              style={{ color: textColor }}
+            />
+          ) : (
+            <Icon
+              name="cancel"
+              isFill
+              onClick={handleCancel}
+              style={{ color: textColor }}
+            />
+          )}
         </StyledDropDownButton>
+
         {isOpen && (
           <StyledDropDownOption
             $width={width || '160px'}

--- a/src/Components/Common/DropDown/index.tsx
+++ b/src/Components/Common/DropDown/index.tsx
@@ -10,6 +10,11 @@ import {
 } from './style';
 import Icon from '@/Components/Base/Icon';
 
+/**
+ * @param options: 출력할 옵션들을 배열([])형태로 담아 전달해주세요. (필수)
+ * 이 외의 프롭들은 선택적으로 전달해줄 수 있으며, px / rem 등의 단위가 포함된 String 형태로 전달해주세요.
+ */
+
 const DropDown = forwardRef(
   (
     {
@@ -71,8 +76,8 @@ const DropDown = forwardRef(
         )}
         <StyledDropDownButton
           onClick={() => setIsOpen(!isOpen)}
-          $width={width || '160px'}
-          $height={height || '40px'}
+          $width={width || '16rem'}
+          $height={height || '4rem'}
           $backgroundColor={backgroundColor || theme.colors.background}
           $textColor={textColor || theme.colors.text}
           $textSize={textSize || theme.size.medium}
@@ -98,7 +103,7 @@ const DropDown = forwardRef(
 
         {isOpen && (
           <StyledDropDownOption
-            $width={width || '160px'}
+            $width={width || '16rem'}
             {...optionProps}
           >
             {options.map((option) => (
@@ -110,7 +115,7 @@ const DropDown = forwardRef(
                 }
                 $itemTextColor={itemTextColor || theme.colors.text}
                 $itemTextSize={itemTextSize || theme.size.small}
-                $width={width || '160px'}
+                $width={width || '16rem'}
                 {...itemProps}
               >
                 {option}

--- a/src/Components/Common/DropDown/style.ts
+++ b/src/Components/Common/DropDown/style.ts
@@ -1,9 +1,24 @@
 import styled from 'styled-components';
-import { StyledDropDownButtonProp, StyledDropDownItemProp } from './type';
+import {
+  StyledDropDownButtonProp,
+  StyledDropDownItemProp,
+  StyledLabelProp,
+} from './type';
 
 export const StyledDropDown = styled.div`
   position: relative;
   display: inline-block;
+`;
+
+export const StyledLabel = styled.span<StyledLabelProp>`
+  position: absolute;
+  left: 8px;
+  top: -10px;
+  color: ${({ $labelTextColor }) => $labelTextColor};
+  font-size: ${({ $labelTextSize }) => $labelTextSize};
+  background-color: ${({ $backgroundColor }) => $backgroundColor};
+  padding: 0px 5px;
+  font-weight: 900;
 `;
 
 export const StyledDropDownButton = styled.button<StyledDropDownButtonProp>`

--- a/src/Components/Common/DropDown/style.ts
+++ b/src/Components/Common/DropDown/style.ts
@@ -12,13 +12,14 @@ export const StyledDropDown = styled.div`
 
 export const StyledLabel = styled.span<StyledLabelProp>`
   position: absolute;
-  left: 8px;
-  top: -10px;
+  left: 0.8rem;
+  top: -1rem;
   color: ${({ $labelTextColor }) => $labelTextColor};
   font-size: ${({ $labelTextSize }) => $labelTextSize};
   background-color: ${({ $backgroundColor }) => $backgroundColor};
-  padding: 0px 5px;
-  font-weight: 900;
+  padding: 0rem 0.5rem;
+  font-weight: ${({ theme }) => theme.fontWeight.black};
+  user-select: none;
 `;
 
 export const StyledDropDownButton = styled.button<StyledDropDownButtonProp>`
@@ -29,11 +30,11 @@ export const StyledDropDownButton = styled.button<StyledDropDownButtonProp>`
   height: ${({ $height }) => $height};
   background-color: ${({ $backgroundColor }) => $backgroundColor};
   color: ${({ $textColor }) => $textColor};
-  padding: 10px 12px;
+  padding: 1rem 1.2rem;
   font-size: ${({ $textSize }) => $textSize};
   border: 2px solid black;
   border-radius: 1rem;
-  gap: 12px;
+  gap: 1.2rem;
 `;
 
 export const StyledDropDownOption = styled.div<{ $width: string }>`
@@ -49,10 +50,11 @@ export const StyledDropDownOption = styled.div<{ $width: string }>`
 
 export const StyledDropDownItem = styled.div<StyledDropDownItemProp>`
   width: 100%;
-  padding: 12px 16px;
+  padding: 1.2rem 1.6rem;
   background-color: ${({ $itemBackgroundColor }) => $itemBackgroundColor};
   color: ${({ $itemTextColor }) => $itemTextColor};
   font-size: ${({ $itemTextSize }) => $itemTextSize};
+  user-select: none;
   cursor: pointer;
 
   &:hover {

--- a/src/Components/Common/DropDown/style.ts
+++ b/src/Components/Common/DropDown/style.ts
@@ -7,29 +7,37 @@ export const StyledDropDown = styled.div`
 `;
 
 export const StyledDropDownButton = styled.button<StyledDropDownButtonProp>`
-  min-width: 160px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background-color: #4caf50;
-  color: white;
-  padding: 16px;
-  font-size: 16px;
-  border: none;
+  width: ${({ $width }) => $width};
+  height: ${({ $height }) => $height};
+  background-color: ${({ $backgroundColor }) => $backgroundColor};
+  color: ${({ $textColor }) => $textColor};
+  padding: 10px 12px;
+  font-size: ${({ $textSize }) => $textSize};
+  border: 2px solid black;
+  border-radius: 1rem;
+  gap: 12px;
 `;
 
-export const StyledDropDownOption = styled.div<{ $size: string }>`
+export const StyledDropDownOption = styled.div<{ $width: string }>`
   display: block;
   position: absolute;
-  min-width: ${({ $size }) => $size};
+  width: ${({ $width }) => $width};
   z-index: 1;
   box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
   background-color: #f9f9f9;
+  border-radius: 1rem;
+  overflow: hidden;
 `;
 
 export const StyledDropDownItem = styled.div<StyledDropDownItemProp>`
   width: 100%;
   padding: 12px 16px;
+  background-color: ${({ $itemBackgroundColor }) => $itemBackgroundColor};
+  color: ${({ $itemTextColor }) => $itemTextColor};
+  font-size: ${({ $itemTextSize }) => $itemTextSize};
   cursor: pointer;
 
   &:hover {

--- a/src/Components/Common/DropDown/style.ts
+++ b/src/Components/Common/DropDown/style.ts
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+import { StyledDropDownButtonProp, StyledDropDownItemProp } from './type';
+
+export const StyledDropDown = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
+export const StyledDropDownButton = styled.button<StyledDropDownButtonProp>`
+  min-width: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #4caf50;
+  color: white;
+  padding: 16px;
+  font-size: 16px;
+  border: none;
+`;
+
+export const StyledDropDownOption = styled.div<{ $size: string }>`
+  display: block;
+  position: absolute;
+  min-width: ${({ $size }) => $size};
+  z-index: 1;
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+  background-color: #f9f9f9;
+`;
+
+export const StyledDropDownItem = styled.div<StyledDropDownItemProp>`
+  width: 100%;
+  padding: 12px 16px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: lightgray;
+  }
+`;

--- a/src/Components/Common/DropDown/type.ts
+++ b/src/Components/Common/DropDown/type.ts
@@ -19,6 +19,13 @@ export interface DropDownProps {
   buttonProps?: HTMLAttributes<HTMLElement>;
   optionProps?: HTMLAttributes<HTMLElement>;
   itemProps?: HTMLAttributes<HTMLElement>;
+  labelProps?: HTMLAttributes<HTMLElement>;
+}
+
+export interface StyledLabelProp extends HTMLAttributes<HTMLDivElement> {
+  $labelTextColor: string;
+  $labelTextSize: string;
+  $backgroundColor: string;
 }
 
 export interface StyledDropDownButtonProp

--- a/src/Components/Common/DropDown/type.ts
+++ b/src/Components/Common/DropDown/type.ts
@@ -1,0 +1,35 @@
+import { HTMLAttributes, ButtonHTMLAttributes } from 'react';
+
+export interface DropDownProps {
+  options: string[];
+  label?: string;
+  labelTextColor?: string;
+  labelTextSize?: string;
+  width?: string;
+  height?: string;
+  backgroundColor?: string;
+  textColor?: string;
+  textSize?: string;
+  itemBackgroundColor?: string;
+  itemTextColor?: string;
+  itemTextSize?: string;
+  onSelect?: (selected: string) => void;
+
+  buttonProps?: HTMLAttributes<HTMLElement>;
+  optionProps?: HTMLAttributes<HTMLElement>;
+  itemProps?: HTMLAttributes<HTMLElement>;
+}
+
+export interface StyledDropDownButtonProp
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  $width: string;
+  $height: string;
+  $backgroundColor: string;
+  $textColor: string;
+}
+
+export interface StyledDropDownItemProp {
+  $itemBackgroundColor: string;
+  $itemTextColor: string;
+  $itemTextSize: string;
+}

--- a/src/Components/Common/DropDown/type.ts
+++ b/src/Components/Common/DropDown/type.ts
@@ -1,6 +1,7 @@
-import { HTMLAttributes, ButtonHTMLAttributes } from 'react';
+import { HTMLAttributes, ButtonHTMLAttributes, ReactNode } from 'react';
 
 export interface DropDownProps {
+  children?: ReactNode;
   options: string[];
   label?: string;
   labelTextColor?: string;
@@ -26,10 +27,12 @@ export interface StyledDropDownButtonProp
   $height: string;
   $backgroundColor: string;
   $textColor: string;
+  $textSize: string;
 }
 
 export interface StyledDropDownItemProp {
   $itemBackgroundColor: string;
   $itemTextColor: string;
   $itemTextSize: string;
+  $width: string;
 }

--- a/src/Styles/Theme.ts
+++ b/src/Styles/Theme.ts
@@ -6,6 +6,7 @@ const commonTheme = {
   alert: '#FF0000', // 알림 색상
   border: '#CCCCCC', // 보더 색상
   backgroundGrey: '#D1CCC7', // 회색 배경 색상
+  lightGray: '#F0F0F0', // 밝은 회색 색상
   focusHover: '#F2F2F2', // 포커스 및 호버 색상
   focusHoverText: '#000000',
   overlay: 'rgba(0, 0, 0, 0.4)', // 오버레이 색상


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/dropDownComponent` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
![Jan-03-2024 01-08-20](https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/assets/95916813/6c77b96f-0ce4-4092-9cb5-9b1583aef64a)
(`drop-shadow`는 차이가 있습니다.)

1. `options=[]` 프롭을 통해 데이터를 렌더링하는 드롭다운 컴포넌트입니다.
2. 배경색, 글씨색, 글씨크기 등의 자주 사용되는 프롭들을 선택적으로 넘겨줄 수 있으며, 요소마다 부착된 {...elementProp}으로 부가적인 프롭을 전달할 수 있습니다.
3. 내부에서 현재 선택된 옵션을 State로 관리하며, 기본값은 `'선택 없음'`입니다. 이 경우 우측 버튼이 하단화살표 모양을 띄고, 클릭 시 드롭다운이 토글됩니다.
4. 유효한 옵션이 선택된 상태일 경우 우측 버튼은 취소 모양을 띄고, 클릭 시 '선택 없음' 옵션으로 초기화되고, 드롭다운이 닫히게 됩니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] 프롭 타입, 컴포넌트 설정
- [x] 스타일 프롭 바인딩 및 스타일링
- [x] 레이블 추가

> 피드백 반영

- 기존에 부여했던 스타일 단위들을 반응형(rem)으로 수정하였습니다.

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
1. 프롭, 로직, 확장성 등등 관련하여 피드백 부탁드립니다.