### PR TITLE
Fix: Modal 컴포넌트 wrapper 너비 및 높이 수정

### DIFF
--- a/src/Components/Common/Modal/style.ts
+++ b/src/Components/Common/Modal/style.ts
@@ -5,8 +5,8 @@ export const StyledModalWrapper = styled.div`
   position: absolute;
   top: 0;
   left: 0;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/fixModal` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
모달이 아래쪽으로 치우치는 버그를 수정하기 위해 모달의 wrapper이 너비와 높이를 100vw, 100vh에서 부모요소의 100%로 변경했습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `Modal/style.ts` : width, height 100%로 변경

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 다른 예외적이 에러 있으면 언제든지 말씀해주세요!

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
[Feat: Common Modal 컴포넌트 구현 #9](https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/pull/9)
