### PR TITLE
Feat: UserCard 공용 컴포넌트 구현

### DIFF
--- a/src/Components/Common/UserCard/index.tsx
+++ b/src/Components/Common/UserCard/index.tsx
@@ -14,11 +14,13 @@ import Badge from '@/Components/Base/Badge';
 import Button from '@/Components/Base/Button';
 
 /**
+ * @param mode normal, chat, alarm, follow 모드 변경 가능
  * @param coverImageUrl 아바타 이미지 url
  * @param avatarSize 아바타 이미지 사이즈 (px)
  * @param badgeSize 배지 사이즈 (rem)
  * @param isOnline 유저 온라인 여부
  * @param isRead 유저 채팅 읽음 여부
+ * @param isFollow 해당 유저 팔로우 여부
  * @param onClick 내부 요소 클릭 이벤트 추출하는 함수
  */
 const UserCard = forwardRef(
@@ -46,6 +48,10 @@ const UserCard = forwardRef(
   ) => {
     const { colors, size, fontWeight } = useTheme();
 
+    /**
+     * UserCard 내 요소 클릭 시 클릭이벤트 전달용 함수
+     * 어떻게 사용 및 확장할지는 추후 결정해야 할듯
+     */
     const handleClick = (e: MouseEvent<HTMLDivElement>) => {
       if (onClick && e.target === e.currentTarget) {
         onClick(e);
@@ -60,6 +66,7 @@ const UserCard = forwardRef(
         $borderRadius={borderRadius || ''}
         {...props}
       >
+        {/* 유저 아바타 */}
         <Avatar
           src={coverImageUrl || ''}
           className="user-avatar"
@@ -76,6 +83,7 @@ const UserCard = forwardRef(
             />
           )}
         </Avatar>
+        {/* 유저 아이디 및 세부 상태 정보 */}
         <StyledUserInfoContainer>
           <StyledUserName
             fontSize={userNameSize || size.small}
@@ -93,6 +101,7 @@ const UserCard = forwardRef(
             </StyledUserDetail>
           )}
         </StyledUserInfoContainer>
+        {/* follow 모드 시 팔로우 버튼 */}
         {mode === 'follow' && (
           <StyledUserFollowContainer>
             <Button
@@ -107,6 +116,7 @@ const UserCard = forwardRef(
             </Button>
           </StyledUserFollowContainer>
         )}
+        {/* chat, alarm 모드 시 읽음 배지 */}
         {(mode === 'chat' || mode === 'alarm') && (
           <StyledUserReadContainer $badgeSize={badgeSize}>
             {!isRead && (

--- a/src/Components/Common/UserCard/index.tsx
+++ b/src/Components/Common/UserCard/index.tsx
@@ -1,0 +1,108 @@
+import { useTheme } from 'styled-components';
+import { ForwardedRef, MouseEvent, forwardRef } from 'react';
+import Avatar from '@/Components/Base/Avatar';
+import {
+  StyledUserInfoContainer,
+  StyledWrapper,
+  StyledUserName,
+  StyledUserDetail,
+  StyledUserReadContainer,
+} from './style';
+import { UserCardProps } from './type';
+import Badge from '@/Components/Base/Badge';
+
+/**
+ * @param coverImageUrl 아바타 이미지 url
+ * @param avatarSize 아바타 이미지 사이즈 (px)
+ * @param badgeSize 배지 사이즈 (rem)
+ * @param isOnline 유저 온라인 여부
+ * @param isRead 유저 채팅 읽음 여부
+ * @param onClick 내부 요소 클릭 이벤트 추출하는 함수
+ */
+const UserCard = forwardRef(
+  (
+    {
+      width,
+      height,
+      coverImageUrl,
+      avatarSize = 30,
+      badgeSize = '0.8rem',
+      isOnline = false,
+      isRead = false,
+      userName = '',
+      userDetail = null,
+      userNameSize,
+      userNameWeight,
+      userDetailSize,
+      onClick,
+      ...props
+    }: UserCardProps,
+    ref: ForwardedRef<HTMLDivElement>,
+  ) => {
+    const { colors, size, fontWeight } = useTheme();
+
+    const handleClick = (e: MouseEvent<HTMLDivElement>) => {
+      if (onClick && e.target === e.currentTarget) {
+        onClick(e);
+      }
+    };
+
+    return (
+      <StyledWrapper
+        ref={ref}
+        $width={width || '100%'}
+        $height={height || '100%'}
+        {...props}
+      >
+        <Avatar
+          src={coverImageUrl || ''}
+          className="user-avatar"
+          size={avatarSize}
+          onClick={handleClick}
+        >
+          {isOnline && (
+            <Badge
+              position="rightBottom"
+              size={badgeSize}
+              backgroundColor={colors.online}
+              style={{ border: `1px solid ${colors.background}` }}
+              onClick={handleClick}
+            />
+          )}
+        </Avatar>
+        <StyledUserInfoContainer>
+          <StyledUserName
+            fontSize={userNameSize || size.small}
+            fontWeight={userNameWeight || fontWeight.medium}
+            onClick={handleClick}
+          >
+            {userName}
+          </StyledUserName>
+          {userDetail && (
+            <StyledUserDetail
+              fontSize={userDetailSize || '0.8rem'}
+              onClick={handleClick}
+            >
+              {userDetail}
+            </StyledUserDetail>
+          )}
+        </StyledUserInfoContainer>
+        <StyledUserReadContainer $badgeSize={badgeSize}>
+          {!isRead && (
+            <Badge
+              position="leftTop"
+              size={badgeSize}
+              backgroundColor={colors.read}
+              style={{ border: `1px solid ${colors.background}` }}
+              onClick={handleClick}
+            />
+          )}
+        </StyledUserReadContainer>
+      </StyledWrapper>
+    );
+  },
+);
+
+UserCard.displayName = 'UserCard';
+
+export default UserCard;

--- a/src/Components/Common/UserCard/index.tsx
+++ b/src/Components/Common/UserCard/index.tsx
@@ -7,9 +7,11 @@ import {
   StyledUserName,
   StyledUserDetail,
   StyledUserReadContainer,
+  StyledUserFollowContainer,
 } from './style';
 import { UserCardProps } from './type';
 import Badge from '@/Components/Base/Badge';
+import Button from '@/Components/Base/Button';
 
 /**
  * @param coverImageUrl 아바타 이미지 url
@@ -24,11 +26,14 @@ const UserCard = forwardRef(
     {
       width,
       height,
+      borderRadius,
+      mode = 'normal',
       coverImageUrl,
       avatarSize = 30,
       badgeSize = '0.8rem',
       isOnline = false,
       isRead = false,
+      isFollow = false,
       userName = '',
       userDetail = null,
       userNameSize,
@@ -52,6 +57,7 @@ const UserCard = forwardRef(
         ref={ref}
         $width={width || '100%'}
         $height={height || '100%'}
+        $borderRadius={borderRadius || ''}
         {...props}
       >
         <Avatar
@@ -87,17 +93,33 @@ const UserCard = forwardRef(
             </StyledUserDetail>
           )}
         </StyledUserInfoContainer>
-        <StyledUserReadContainer $badgeSize={badgeSize}>
-          {!isRead && (
-            <Badge
-              position="leftTop"
-              size={badgeSize}
-              backgroundColor={colors.read}
-              style={{ border: `1px solid ${colors.background}` }}
-              onClick={handleClick}
-            />
-          )}
-        </StyledUserReadContainer>
+        {mode === 'follow' && (
+          <StyledUserFollowContainer>
+            <Button
+              width="100%"
+              height="2rem"
+              className="follow-button"
+              borderRadius="0.5rem"
+              backgroundColor={isFollow ? colors.read : colors.follow}
+              hoverBackgroundColor={colors.buttonClickHover}
+            >
+              {isFollow ? '팔로잉' : '팔로우'}
+            </Button>
+          </StyledUserFollowContainer>
+        )}
+        {(mode === 'chat' || mode === 'alarm') && (
+          <StyledUserReadContainer $badgeSize={badgeSize}>
+            {!isRead && (
+              <Badge
+                position="leftTop"
+                size={badgeSize}
+                backgroundColor={colors.read}
+                style={{ border: `1px solid ${colors.background}` }}
+                onClick={handleClick}
+              />
+            )}
+          </StyledUserReadContainer>
+        )}
       </StyledWrapper>
     );
   },

--- a/src/Components/Common/UserCard/style.ts
+++ b/src/Components/Common/UserCard/style.ts
@@ -17,6 +17,10 @@ export const StyledWrapper = styled.div<StyledWrapperProps>`
   .user-avatar {
     position: relative;
   }
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.focusHover};
+  }
 `;
 
 export const StyledUserInfoContainer = styled.div`

--- a/src/Components/Common/UserCard/style.ts
+++ b/src/Components/Common/UserCard/style.ts
@@ -9,6 +9,7 @@ export const StyledWrapper = styled.div<StyledWrapperProps>`
   padding: 0.5rem 0.5rem;
   width: ${({ $width }) => $width};
   height: ${({ $height }) => $height};
+  border-radius: ${({ $borderRadius }) => $borderRadius};
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.size.extraSmall};
@@ -45,10 +46,18 @@ export const StyledUserDetail = styled.p<StyledUserDetailProps>`
   white-space: nowrap;
 `;
 
+export const StyledUserFollowContainer = styled.div`
+  display: flex;
+
+  .follow-button {
+    padding: 1rem;
+  }
+`;
+
 export const StyledUserReadContainer = styled.div<{ $badgeSize: string }>`
-  width: 5%;
+  width: 10%;
   position: relative;
+  display: flex;
   margin-left: 1.3rem;
   margin-bottom: ${({ $badgeSize }) => $badgeSize};
-  background-color: yellow;
 `;

--- a/src/Components/Common/UserCard/style.ts
+++ b/src/Components/Common/UserCard/style.ts
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+import {
+  StyledUserDetailProps,
+  StyledUserNameProps,
+  StyledWrapperProps,
+} from './type';
+
+export const StyledWrapper = styled.div<StyledWrapperProps>`
+  padding: 0.5rem 0.5rem;
+  width: ${({ $width }) => $width};
+  height: ${({ $height }) => $height};
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.size.extraSmall};
+  background-color: ${({ theme }) => theme.colors.background};
+
+  .user-avatar {
+    position: relative;
+  }
+`;
+
+export const StyledUserInfoContainer = styled.div`
+  width: 50%;
+  flex-grow: 1;
+`;
+
+export const StyledUserName = styled.h1<StyledUserNameProps>`
+  font-size: ${({ fontSize }) => fontSize};
+  font-weight: ${({ fontWeight }) => fontWeight};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const StyledUserDetail = styled.p<StyledUserDetailProps>`
+  font-size: ${({ fontSize }) => fontSize};
+  color: #9f9f9f;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const StyledUserReadContainer = styled.div<{ $badgeSize: string }>`
+  width: 5%;
+  position: relative;
+  margin-left: 1.3rem;
+  margin-bottom: ${({ $badgeSize }) => $badgeSize};
+  background-color: yellow;
+`;

--- a/src/Components/Common/UserCard/type.ts
+++ b/src/Components/Common/UserCard/type.ts
@@ -1,0 +1,30 @@
+import { HTMLAttributes } from 'react';
+
+export interface UserCardProps extends HTMLAttributes<HTMLDivElement> {
+  width?: string;
+  height?: string;
+  coverImageUrl?: string;
+  avatarSize?: number;
+  badgeSize?: string;
+  isOnline?: boolean;
+  isRead?: boolean;
+  userName?: string;
+  userDetail?: string | null;
+  userNameSize?: string;
+  userNameWeight?: string;
+  userDetailSize?: string;
+}
+
+export interface StyledWrapperProps {
+  $width: string;
+  $height: string;
+}
+
+export interface StyledUserNameProps {
+  fontSize: string;
+  fontWeight: string;
+}
+
+export interface StyledUserDetailProps {
+  fontSize: string;
+}

--- a/src/Components/Common/UserCard/type.ts
+++ b/src/Components/Common/UserCard/type.ts
@@ -3,11 +3,14 @@ import { HTMLAttributes } from 'react';
 export interface UserCardProps extends HTMLAttributes<HTMLDivElement> {
   width?: string;
   height?: string;
+  borderRadius?: string;
+  mode?: 'follow' | 'chat' | 'alarm' | 'normal';
   coverImageUrl?: string;
   avatarSize?: number;
   badgeSize?: string;
   isOnline?: boolean;
   isRead?: boolean;
+  isFollow?: boolean;
   userName?: string;
   userDetail?: string | null;
   userNameSize?: string;
@@ -18,6 +21,7 @@ export interface UserCardProps extends HTMLAttributes<HTMLDivElement> {
 export interface StyledWrapperProps {
   $width: string;
   $height: string;
+  $borderRadius: string;
 }
 
 export interface StyledUserNameProps {


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/userCard` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
채팅 유저나 유저 목록 등에 사용될 수 있는 UserCard를 구현했습니다.
![image](https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/assets/70748442/ca835d1e-9119-4b79-a0f1-409409c3330c)


<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
### props
- [x] 기본적인 width, height 조절 가능합니다.
- [x] coverImageUrl과 avatarSize로 아바타 사진 및 크기 조절 가능합니다.
- [x] isOnline, isRead로 온라인 유저와 읽음 여부 처리가 가능합니다.
- [x] userName, userDetail로 유저 이름과 세부 채팅 내용 표시까지 가능합니다.
- [x] userNameSize, userNameWeight로 유저 이름 폰트 크기 및 굵기 조절 가능합니다.

### 피드백 적용사항
### props
- [x] mode를 통해 normal, chat, alarm, follow 모드를 변경 가능합니다.
- [x] isFollow로 팔로우 버튼 처리가 가능합니다.


<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- onClick 이벤트에 대한 처리를 잘 못하겠네요.. 어디부터 해야할지 감이 안 잡혀요.. 사용하시면서 수정할 부분을 알려주시면 좋을 거 같아요!

