### PR TITLE
Feat: 로그인 기능 개발

### DIFF
--- a/src/Api/interceptors.ts
+++ b/src/Api/interceptors.ts
@@ -7,7 +7,8 @@ import { AUTH_TOKEN_KEY } from '@/Constants/Api';
  * 임시로 세션스토리지 사용 중, 추후에 변경 가능성 있습니다.
  */
 const setAuthorization = (config: InternalAxiosRequestConfig) => {
-  const accessToken = sessionStorage.getItem(AUTH_TOKEN_KEY);
+  const accessToken = JSON.parse(sessionStorage.getItem(AUTH_TOKEN_KEY) || '');
+
   if (accessToken) {
     config.headers.Authorization = `Bearer ${accessToken}`;
   }

--- a/src/Components/Common/HistoryBackButton/index.tsx
+++ b/src/Components/Common/HistoryBackButton/index.tsx
@@ -15,6 +15,7 @@ const HistoryBackButton = ({ ...props }: Props) => {
   return (
     <Button
       backgroundColor="transparent"
+      hoverBackgroundColor="transparent"
       onClick={handleOnClick}
       style={{
         width: 'auto',

--- a/src/Components/Common/Logo/index.tsx
+++ b/src/Components/Common/Logo/index.tsx
@@ -3,11 +3,11 @@ import Button from '@/Components/Base/Button';
 import StyledLogoImage from './style';
 import Props from './type';
 import STYLED_LOGO_BLACK from '@/Assets/Images/STYLED-logo-black.png';
-// import STYLED_LOGO_WHITE from '@/Assets/Images/STYLED-logo-white.png';
-// import { useDarkMode } from '@/Stores';
+import STYLED_LOGO_WHITE from '@/Assets/Images/STYLED-logo-white.png';
+import { useDarkModeStore } from '@/Stores';
 
 const Logo = ({ width = '15rem', height = '10rem', ...props }: Props) => {
-  // const { isDarkMode } = useDarkMode();
+  const { isDarkMode } = useDarkModeStore();
   const navigate = useNavigate();
 
   const handleOnClick = () => {
@@ -19,19 +19,17 @@ const Logo = ({ width = '15rem', height = '10rem', ...props }: Props) => {
       width={width}
       height={height}
       backgroundColor="transparent"
+      hoverBackgroundColor="transparent"
       onClick={handleOnClick}
       {...props}
     >
-      {/* 라이트 모드일 떄 검은 로고, 다크 모드일 때 흰 로고 */}
       <StyledLogoImage
-        // src={isDarkMode ? STYLED_LOGO_WHITE : STYLED_LOGO_BLACK}
-        // alt={
-        //   isDarkMode
-        //     ? 'STYLED 프로젝트 다크 모드 로고'
-        //     : 'STYLED 프로젝트 라이트 모드 로고'
-        // }
-        src={STYLED_LOGO_BLACK}
-        alt="STYLED 프로젝트 다크 모드 로고"
+        src={isDarkMode ? STYLED_LOGO_WHITE : STYLED_LOGO_BLACK}
+        alt={
+          isDarkMode
+            ? 'STYLED 프로젝트 다크 모드 로고'
+            : 'STYLED 프로젝트 라이트 모드 로고'
+        }
       />
     </Button>
   );

--- a/src/Components/Login/LoginForm/type.ts
+++ b/src/Components/Login/LoginForm/type.ts
@@ -1,4 +1,11 @@
-export default interface ValidateLoginProps {
+import { UserResponseType } from '@/Types/Response';
+
+export interface ValidateLoginProps {
   email: string;
   password: string;
+}
+
+export interface Props {
+  onSuccessCallback: (response: UserResponseType) => void;
+  onErrorCallback: () => void;
 }

--- a/src/Components/Login/MoveToSignUpButton/index.tsx
+++ b/src/Components/Login/MoveToSignUpButton/index.tsx
@@ -17,6 +17,8 @@ const MoveToSignUpButton = () => {
       textColor={colors.buttonText}
       backgroundColor={colors.buttonBackground}
       borderRadius={size.small}
+      hoverBackgroundColor={colors.buttonClickHover}
+      hoverTextColor={colors.text}
       onClick={handleOnClick}
       style={{ padding: size.doubleLarge }}
     >

--- a/src/Hooks/UseForm/index.ts
+++ b/src/Hooks/UseForm/index.ts
@@ -1,9 +1,9 @@
 import { ChangeEvent, FormEvent, useState } from 'react';
-import type { InitialState, ErrorMessages, Props } from './type';
+import type { Props } from './type';
 
-const useForm = ({ initialState, callback, validate }: Props) => {
-  const [values, setValues] = useState<InitialState>(initialState);
-  const [errors, setErrors] = useState<ErrorMessages>({});
+const useForm = <T>({ initialState, callback, validate }: Props<T>) => {
+  const [values, setValues] = useState<T>(initialState);
+  const [errors, setErrors] = useState<Partial<T>>({});
   const [isLoading, setIsLoading] = useState(false);
 
   const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/Hooks/UseForm/type.ts
+++ b/src/Hooks/UseForm/type.ts
@@ -1,8 +1,5 @@
-export type InitialState = Record<string, string | boolean>;
-export type ErrorMessages = Record<string, string>;
-
-export interface Props {
-  initialState: InitialState;
-  callback?: () => Promise<void> | void;
-  validate: (values: InitialState) => ErrorMessages;
+export interface Props<T> {
+  initialState: T;
+  callback: () => void | Promise<unknown>;
+  validate: (values: T) => Partial<T>;
 }

--- a/src/Pages/LoginPage/index.tsx
+++ b/src/Pages/LoginPage/index.tsx
@@ -25,7 +25,12 @@ const LoginPage = () => {
   // 인증 되었으면 접근 불가 처리
   const { mutate, status } = useMutation({
     mutationFn: checkAuth,
-    onSuccess: (response) => response && navigator('/'),
+    onSuccess: (response) => {
+      if (response) {
+        setAuthUser(response);
+        navigator('/');
+      }
+    },
   });
 
   const onSuccessCallback = useCallback(

--- a/src/Pages/LoginPage/index.tsx
+++ b/src/Pages/LoginPage/index.tsx
@@ -1,18 +1,72 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { useTheme } from 'styled-components';
 import MoveToSignUpButton from '@/Components/Login/MoveToSignUpButton';
 import { StyledWrap, StyledContainer } from './style';
 import LoginForm from '@/Components/Login/LoginForm';
 import Logo from '@/Components/Common/Logo';
 import HistoryBackButton from '@/Components/Common/HistoryBackButton';
+import { checkAuth } from '@/Services/Auth';
+import Spinner from '@/Components/Base/Spinner';
+import { UserResponseType } from '@/Types/Response';
+import useAuthUserStore from '@/Stores/AuthUser';
+import { useSessionStorage } from '@/Hooks';
+import { AUTH_TOKEN_KEY } from '@/Constants/Api';
+import Alert from '@/Components/Common/Alert';
 
 const LoginPage = () => {
+  const navigator = useNavigate();
+  const { colors } = useTheme();
+  const [, setSessionToken] = useSessionStorage(AUTH_TOKEN_KEY, '');
+  const { setAuthUser } = useAuthUserStore();
+  const [loginErrorMessage, setLoginErrorMessage] = useState('');
+
+  // 인증 되었으면 접근 불가 처리
+  const { mutate, status } = useMutation({
+    mutationFn: checkAuth,
+    onSuccess: (response) => response && navigator('/'),
+  });
+
+  const onSuccessCallback = useCallback(
+    ({ token, user }: UserResponseType) => {
+      setAuthUser(user);
+      setSessionToken(token);
+      navigator('/');
+    },
+    [navigator, setAuthUser, setSessionToken],
+  );
+
+  const onErrorCallback = useCallback(() => {
+    setLoginErrorMessage('로그인 실패');
+  }, []);
+
+  useEffect(() => {
+    mutate();
+  }, [mutate]);
+
   return (
     <StyledWrap>
-      <StyledContainer>
-        <HistoryBackButton className="history-back-button" />
-        <Logo />
-        <LoginForm />
-        <MoveToSignUpButton />
-      </StyledContainer>
+      {status !== 'success' ? (
+        <Spinner color={colors.primary} />
+      ) : (
+        <StyledContainer>
+          <HistoryBackButton className="history-back-button" />
+          <Logo />
+          <LoginForm
+            onSuccessCallback={onSuccessCallback}
+            onErrorCallback={onErrorCallback}
+          />
+          <MoveToSignUpButton />
+        </StyledContainer>
+      )}
+
+      {loginErrorMessage && (
+        <Alert
+          message={loginErrorMessage}
+          onChangeOpen={() => setLoginErrorMessage('')}
+        />
+      )}
     </StyledWrap>
   );
 };

--- a/src/Stores/AuthUser/index.ts
+++ b/src/Stores/AuthUser/index.ts
@@ -1,0 +1,10 @@
+import { create } from 'zustand';
+import { AuthUserType } from './type';
+import { UserType } from '@/Types/UserType';
+
+const useAuthUserStore = create<AuthUserType>((set) => ({
+  user: {},
+  setAuthUser: (user: Partial<UserType>) => set({ user }),
+}));
+
+export default useAuthUserStore;

--- a/src/Stores/AuthUser/type.ts
+++ b/src/Stores/AuthUser/type.ts
@@ -1,0 +1,6 @@
+import { UserType } from '@/Types/UserType';
+
+export interface AuthUserType {
+  user: Partial<UserType>;
+  setAuthUser: (user: Partial<UserType>) => void;
+}

--- a/src/Stores/DarkMode/index.ts
+++ b/src/Stores/DarkMode/index.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { IsDarkModeType } from './type';
 
 const useDarkModeStore = create<IsDarkModeType>((set) => ({

--- a/src/Styles/Theme.ts
+++ b/src/Styles/Theme.ts
@@ -10,7 +10,7 @@ const commonTheme = {
   focusHover: '#F2F2F2', // 포커스 및 호버 색상
   focusHoverText: '#000000',
   overlay: 'rgba(0, 0, 0, 0.4)', // 오버레이 색상
-  buttonClickHover: 'rgba(0, 0, 0, 0.3)', // 버튼 클릭 시 호버 색상
+  buttonClickHover: '#E0E0E0', // 버튼 클릭 시 호버 색상
   follow: 'rgba(119, 82, 254, 1)', // 팔로우 색상
 };
 


### PR DESCRIPTION
## ✨ 반영 브랜치
`feature/login` -> `dev`

## 📝 설명
로그인 기능 개발

로그인 성공 시
- 로그인 전역 상태 추가
- 세션 스토리지 token 추가
- 메인 페이지로 이동

로그인 실패 시
- Alert 컴포넌트 모달 제공

인증 상태에서 로그인 페이지 진입 시
- 세션 스토리지 토큰을 이용해 인증 되었는지 확인
- 인증 되었다면 유저 정보를 전역 상태에 담는다.
- 인증 되었다면 메인 페이지로 이동

![image](https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/assets/87266785/cd44db93-7767-42bf-942b-11edd56b0893)

![image](https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/assets/87266785/8b09948a-1db2-4c3f-8198-f9e8f8d4e15f)

## ✅ 변경 사항
- [x] useForm 커스텀 훅 타입을 제너릭 기준으로 변경
- [x] store에 User 데이터 추가
- [x] axios 인터셉터 세션 스토리지 파싱에 있어 JSON 형태로 가져오는 버그 수정 

## 💬 PR 포인트 & 질문사항
Alert 모달을 띄우긴 했는데 다크모드 시 적용할 부분이 좀 있는 것 같습니다! 추가적으로 폰트 크기도 조절할 수 있으면 좋겠어요!
