### PR TITLE
Feat: 전체 사용자 목록 조회

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-intersection-observer": "^9.5.3",
         "react-router-dom": "^6.21.1",
         "styled-components": "^6.1.3",
         "styled-reset": "^4.5.1",
@@ -4492,6 +4493,14 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.5.3.tgz",
+      "integrity": "sha512-NJzagSdUPS5rPhaLsHXYeJbsvdpbJwL6yCHtMk91hc0ufQ2BnXis+0QQ9NBh6n9n+Q3OyjR6OQLShYbaNBkThQ==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^9.5.3",
     "react-router-dom": "^6.21.1",
     "styled-components": "^6.1.3",
     "styled-reset": "^4.5.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { lightTheme, darkTheme } from '@/Styles/Theme';
 import GlobalStyle from '@/Styles/Global';
 import RouteManager from '@/Routes/Router';
 import { useDarkModeStore } from './Stores';
-import UserManager from './Components/UserManager';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -20,7 +19,6 @@ const App = () => {
       <QueryClientProvider client={queryClient}>
         <GlobalStyle />
         <RouteManager />
-        <UserManager />
       </QueryClientProvider>
     </ThemeProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { lightTheme, darkTheme } from '@/Styles/Theme';
 import GlobalStyle from '@/Styles/Global';
 import RouteManager from '@/Routes/Router';
 import { useDarkModeStore } from './Stores';
+import UserManager from './Components/UserManager';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -19,6 +20,7 @@ const App = () => {
       <QueryClientProvider client={queryClient}>
         <GlobalStyle />
         <RouteManager />
+        <UserManager />
       </QueryClientProvider>
     </ThemeProvider>
   );

--- a/src/Components/UserManager/UserItem/index.tsx
+++ b/src/Components/UserManager/UserItem/index.tsx
@@ -1,33 +1,50 @@
-import styled, { useTheme } from 'styled-components';
+import { useTheme } from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import { ForwardedRef, forwardRef } from 'react';
 import Avatar from '@/Components/Base/Avatar';
 import { Props } from './type';
 import Badge from '@/Components/Base/Badge';
+import { StyledContainer, StyledUserName } from './style';
 
-const StyledContainer = styled.li``;
+const UserItem = forwardRef(
+  (
+    { id, coverImage, isOnline, fullName }: Props,
+    ref: ForwardedRef<HTMLLIElement>,
+  ) => {
+    const { colors } = useTheme();
+    const navigator = useNavigate();
+    const defaultImage =
+      'https://user-images.githubusercontent.com/17202261/101670093-195d9180-3a96-11eb-9bd4-9f31cbe44aea.png';
 
-const UserItem = ({ coverImage, isOnline, fullName }: Props) => {
-  const { colors } = useTheme();
+    const handleOnClick = () => {
+      navigator(`/user/${id}`);
+    };
 
-  return (
-    <StyledContainer>
-      <Avatar
-        src={coverImage}
-        className="user-avatar"
-        size={30}
+    return (
+      <StyledContainer
+        $isOnline={isOnline}
+        onClick={handleOnClick}
+        ref={ref}
       >
-        {!isOnline && (
-          <Badge
-            position="rightBottom"
-            backgroundColor={colors.online}
-            style={{ border: `1px solid ${colors.background}` }}
-          />
-        )}
-      </Avatar>
-      <StyledUserInfoContainer>
+        <Avatar
+          src={coverImage || defaultImage}
+          alt="사용자 이미지"
+          size={40}
+        >
+          {isOnline && (
+            <Badge
+              position="rightBottom"
+              backgroundColor={colors.online}
+              style={{ border: `1px solid ${colors.background}` }}
+            />
+          )}
+        </Avatar>
         <StyledUserName>{fullName}</StyledUserName>
-      </StyledUserInfoContainer>
-    </StyledContainer>
-  );
-};
+      </StyledContainer>
+    );
+  },
+);
+
+UserItem.displayName = 'UserItem';
 
 export default UserItem;

--- a/src/Components/UserManager/UserItem/index.tsx
+++ b/src/Components/UserManager/UserItem/index.tsx
@@ -1,0 +1,33 @@
+import styled, { useTheme } from 'styled-components';
+import Avatar from '@/Components/Base/Avatar';
+import { Props } from './type';
+import Badge from '@/Components/Base/Badge';
+
+const StyledContainer = styled.li``;
+
+const UserItem = ({ coverImage, isOnline, fullName }: Props) => {
+  const { colors } = useTheme();
+
+  return (
+    <StyledContainer>
+      <Avatar
+        src={coverImage}
+        className="user-avatar"
+        size={30}
+      >
+        {!isOnline && (
+          <Badge
+            position="rightBottom"
+            backgroundColor={colors.online}
+            style={{ border: `1px solid ${colors.background}` }}
+          />
+        )}
+      </Avatar>
+      <StyledUserInfoContainer>
+        <StyledUserName>{fullName}</StyledUserName>
+      </StyledUserInfoContainer>
+    </StyledContainer>
+  );
+};
+
+export default UserItem;

--- a/src/Components/UserManager/UserItem/index.tsx
+++ b/src/Components/UserManager/UserItem/index.tsx
@@ -17,7 +17,7 @@ const UserItem = forwardRef(
       'https://user-images.githubusercontent.com/17202261/101670093-195d9180-3a96-11eb-9bd4-9f31cbe44aea.png';
 
     const handleOnClick = () => {
-      navigator(`/user/${id}`);
+      navigator(`/profile/${id}`);
     };
 
     return (

--- a/src/Components/UserManager/UserItem/style.ts
+++ b/src/Components/UserManager/UserItem/style.ts
@@ -5,7 +5,7 @@ export const StyledContainer = styled.li<{ $isOnline: boolean }>`
   align-items: center;
   gap: ${({ theme }) => theme.size.small};
   background-color: ${({ theme }) => theme.colors.background};
-  order: ${({ $isOnline }) => ($isOnline ? 1 : 0)};
+  order: ${({ $isOnline }) => ($isOnline ? 0 : 1)};
   padding: ${({ theme }) => theme.size.small};
 
   &:hover {

--- a/src/Components/UserManager/UserItem/style.ts
+++ b/src/Components/UserManager/UserItem/style.ts
@@ -9,12 +9,11 @@ export const StyledContainer = styled.li<{ $isOnline: boolean }>`
   padding: ${({ theme }) => theme.size.small};
 
   &:hover {
-    border-radius: ${({ theme }) => theme.size.medium};
     background-color: ${({ theme }) => theme.colors.buttonClickHover};
     cursor: pointer;
 
     > span {
-      color: ${({ theme }) => theme.colors.buttonText};
+      color: ${({ theme }) => theme.colors.focusHoverText};
     }
   }
 `;

--- a/src/Components/UserManager/UserItem/style.ts
+++ b/src/Components/UserManager/UserItem/style.ts
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+
+export const StyledContainer = styled.li<{ $isOnline: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.size.small};
+  background-color: ${({ theme }) => theme.colors.background};
+  order: ${({ $isOnline }) => ($isOnline ? 1 : 0)};
+  padding: ${({ theme }) => theme.size.small};
+
+  &:hover {
+    border-radius: ${({ theme }) => theme.size.medium};
+    background-color: ${({ theme }) => theme.colors.buttonClickHover};
+    cursor: pointer;
+
+    > span {
+      color: ${({ theme }) => theme.colors.buttonText};
+    }
+  }
+`;
+
+export const StyledUserName = styled.span`
+  font-size: ${({ theme }) => theme.size.medium};
+  height: 100%;
+  flex-grow: 1;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: ${({ theme }) => theme.colors.text};
+`;

--- a/src/Components/UserManager/UserItem/type.ts
+++ b/src/Components/UserManager/UserItem/type.ts
@@ -1,0 +1,5 @@
+export interface Props {
+  coverImage: string;
+  isOnline: boolean;
+  fullName: string;
+}

--- a/src/Components/UserManager/UserItem/type.ts
+++ b/src/Components/UserManager/UserItem/type.ts
@@ -1,5 +1,6 @@
 export interface Props {
-  coverImage: string;
+  id: string;
+  coverImage?: string;
   isOnline: boolean;
   fullName: string;
 }

--- a/src/Components/UserManager/UserList/index.tsx
+++ b/src/Components/UserManager/UserList/index.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+import { Props } from './type';
+
+const StyledUserList = styled.ul``;
+
+const UserList = ({ userList, onlineUserLIst }: Props) => {
+  return <StyledUserList>{/*  */}</StyledUserList>;
+};
+
+export default UserList;

--- a/src/Components/UserManager/UserList/index.tsx
+++ b/src/Components/UserManager/UserList/index.tsx
@@ -1,10 +1,46 @@
-import styled from 'styled-components';
+import { useInView } from 'react-intersection-observer';
+import { useEffect } from 'react';
 import { Props } from './type';
+import UserItem from '../UserItem';
+import { UserType } from '@/Types/UserType';
+import StyledUserList from './style';
 
-const StyledUserList = styled.ul``;
+const UserList = ({
+  isLoading,
+  isEnd,
+  userList,
+  onlineUserList,
+  loadMoreUsers,
+}: Props) => {
+  const { ref, inView } = useInView({ threshold: 0 });
 
-const UserList = ({ userList, onlineUserLIst }: Props) => {
-  return <StyledUserList>{/*  */}</StyledUserList>;
+  useEffect(() => {
+    if (inView && !isEnd && !isLoading) {
+      loadMoreUsers();
+    }
+  }, [inView, loadMoreUsers, isEnd, isLoading]);
+
+  return (
+    <StyledUserList>
+      {userList.map(({ _id, coverImage, fullName }: UserType, index) => {
+        const isLast = userList.length === index + 1;
+        const isOnline = onlineUserList.some(
+          ({ _id: onlineUserId }: UserType) => onlineUserId === _id,
+        );
+
+        return (
+          <UserItem
+            key={_id}
+            id={_id}
+            coverImage={coverImage}
+            isOnline={isOnline}
+            fullName={fullName}
+            ref={isLast ? ref : null}
+          />
+        );
+      })}
+    </StyledUserList>
+  );
 };
 
 export default UserList;

--- a/src/Components/UserManager/UserList/style.ts
+++ b/src/Components/UserManager/UserList/style.ts
@@ -1,17 +1,18 @@
 import styled from 'styled-components';
 
 const StyledUserList = styled.ul`
-  padding: ${({ theme }) => theme.size.small};
+  padding: ${({ theme }) => theme.size.small} 0;
   display: flex;
   flex-direction: column;
-  overflow: auto;
   flex: 1 0 90%;
+  overscroll-behavior: contain;
+  overflow: auto;
 
   &::-webkit-scrollbar {
     width: ${({ theme }) => theme.size.small};
   }
   &::-webkit-scrollbar-thumb {
-    background: ${({ theme }) => theme.colors.primary};
+    background: ${({ theme }) => theme.colors.backgroundGrey};
     border-radius: ${({ theme }) => theme.size.extraSmall};
   }
   &::-webkit-scrollbar-track {

--- a/src/Components/UserManager/UserList/style.ts
+++ b/src/Components/UserManager/UserList/style.ts
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+const StyledUserList = styled.ul`
+  padding: ${({ theme }) => theme.size.small};
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+  flex: 1 0 90%;
+
+  &::-webkit-scrollbar {
+    width: ${({ theme }) => theme.size.small};
+  }
+  &::-webkit-scrollbar-thumb {
+    background: ${({ theme }) => theme.colors.primary};
+    border-radius: ${({ theme }) => theme.size.extraSmall};
+  }
+  &::-webkit-scrollbar-track {
+    background-color: ${({ theme }) => theme.colors.background};
+    border-radius: ${({ theme }) => theme.size.extraSmall};
+  }
+`;
+
+export default StyledUserList;

--- a/src/Components/UserManager/UserList/type.ts
+++ b/src/Components/UserManager/UserList/type.ts
@@ -1,0 +1,6 @@
+import { UserType } from '@/Types/UserType';
+
+export interface Props {
+  userList: UserType[];
+  onlineUserLIst: UserType[];
+}

--- a/src/Components/UserManager/UserList/type.ts
+++ b/src/Components/UserManager/UserList/type.ts
@@ -1,6 +1,9 @@
 import { UserType } from '@/Types/UserType';
 
 export interface Props {
+  isLoading: boolean;
+  isEnd: boolean;
   userList: UserType[];
-  onlineUserLIst: UserType[];
+  onlineUserList: UserType[];
+  loadMoreUsers: () => void;
 }

--- a/src/Components/UserManager/UserSearchForm/index.tsx
+++ b/src/Components/UserManager/UserSearchForm/index.tsx
@@ -1,0 +1,8 @@
+import { memo } from 'react';
+import SearchBar from '@/Components/Common/SearchBar';
+
+const UserSearchForm = () => {
+  return <SearchBar />;
+};
+
+export default memo(UserSearchForm);

--- a/src/Components/UserManager/index.tsx
+++ b/src/Components/UserManager/index.tsx
@@ -44,6 +44,7 @@ const UserManager = () => {
    * @returns {void} 반환값 없음
    */
   const loadMoreUsers = useCallback(() => {
+    console.log('렌더링');
     if (!userList || userList.length === 0) {
       return setUsersOption((prevOptions) => ({
         offset: prevOptions.offset,

--- a/src/Components/UserManager/index.tsx
+++ b/src/Components/UserManager/index.tsx
@@ -6,6 +6,7 @@ import StyledWrapper from './style';
 import { getOnlineUsers, getUsers } from '@/Services/User';
 import { UserType } from '@/Types/UserType';
 import QUERY_KEYS from '@/Constants/queryKeys';
+// import Skeleton from '../Base/Skeleton';
 
 const UserManager = () => {
   const [usersOption, setUsersOption] = useState({ offset: 0, limit: 10 });
@@ -18,7 +19,7 @@ const UserManager = () => {
    * @property {UserType[]} data.userList - 불러온 사용자 목록
    * @property {boolean} isLoading - 데이터 로딩 상태
    */
-  const { data: userList, isLoading } = useQuery({
+  const { data: userList, isLoading: allIsLoading } = useQuery({
     queryKey: [QUERY_KEYS.USER_LIST, usersOption.offset, usersOption.limit],
     queryFn: () => getUsers(usersOption),
   });
@@ -30,7 +31,7 @@ const UserManager = () => {
    * @property {UserType[]} data.onlineUserList - 현재 접속 중인 사용자 목록
    * @options {refetchInterval} - 2초마다 API를 재요청하여 데이터를 최신 상태로 유지
    */
-  const { data: onlineUserList } = useQuery({
+  const { data: onlineUserList, isLoading: onlineIsLoading } = useQuery({
     queryKey: [QUERY_KEYS.ONLINE_USER_LIST],
     queryFn: getOnlineUsers,
     refetchInterval: 2000,
@@ -65,13 +66,28 @@ const UserManager = () => {
   return (
     <StyledWrapper>
       {/* <UserSearchForm /> */}
-      <UserList
-        isLoading={isLoading}
-        isEnd={userList?.length === 0}
-        userList={allUserList}
-        onlineUserList={onlineUserList || []}
-        loadMoreUsers={loadMoreUsers}
-      />
+      {/* {allIsLoading ||
+        (onlineIsLoading && (
+          <SkeletonList
+            length={9}
+            style={{ flexGrow: 1 }}
+          >
+            <Skeleton.Circle size="5rem" />
+            <Skeleton.Paragraph
+              line={2}
+              style={{ width: '100%' }}
+            />
+          </SkeletonList>
+        ))} */}
+      {!allIsLoading && !onlineIsLoading && (
+        <UserList
+          isLoading={allIsLoading}
+          isEnd={userList?.length === 0}
+          userList={allUserList}
+          onlineUserList={onlineUserList || []}
+          loadMoreUsers={loadMoreUsers}
+        />
+      )}
     </StyledWrapper>
   );
 };

--- a/src/Components/UserManager/index.tsx
+++ b/src/Components/UserManager/index.tsx
@@ -1,47 +1,76 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import UserList from './UserList';
-import UserSearchForm from './UserSearchForm';
+// import UserSearchForm from './UserSearchForm';
 import StyledWrapper from './style';
 import { getOnlineUsers, getUsers } from '@/Services/User';
 import { UserType } from '@/Types/UserType';
+import QUERY_KEYS from '@/Constants/queryKeys';
 
 const UserManager = () => {
   const [usersOption, setUsersOption] = useState({ offset: 0, limit: 10 });
   const [allUserList, setAllUserList] = useState<UserType[]>([]);
 
-  const { data: userList } = useQuery({
-    queryKey: ['USER_LIST', usersOption.offset, usersOption.limit],
+  /**
+   * 전체 사용자 목록을 불러오는 API 요청을 수행하는 useQuery 훅
+   * @const
+   * @type {Object}
+   * @property {UserType[]} data.userList - 불러온 사용자 목록
+   * @property {boolean} isLoading - 데이터 로딩 상태
+   */
+  const { data: userList, isLoading } = useQuery({
+    queryKey: [QUERY_KEYS.USER_LIST, usersOption.offset, usersOption.limit],
     queryFn: () => getUsers(usersOption),
   });
 
-  const { data: onlineUserList, isFetching } = useQuery({
-    queryKey: ['ONLINE_USER_LIST'],
+  /**
+   * 현재 접속중인 사용자 목록을 불러오는 API 요청을 수행하는 useQuery 훅
+   * @const
+   * @type {Object}
+   * @property {UserType[]} data.onlineUserList - 현재 접속 중인 사용자 목록
+   * @options {refetchInterval} - 2초마다 API를 재요청하여 데이터를 최신 상태로 유지
+   */
+  const { data: onlineUserList } = useQuery({
+    queryKey: [QUERY_KEYS.ONLINE_USER_LIST],
     queryFn: getOnlineUsers,
     refetchInterval: 2000,
   });
 
-  const loadMoreUsers = () => {
-    setUsersOption((prevOptions) => ({
+  /**
+   * 더 많은 유저를 불러오기 위해 offset과 limit을 증가시키는 함수
+   * 만약 받아온 유저목록이 undefined거나 빈 배열일 경우 offset과 limit를 증가시키지 않음
+   * @function loadMoreUsers
+   * @returns {void} 반환값 없음
+   */
+  const loadMoreUsers = useCallback(() => {
+    if (!userList || userList.length === 0) {
+      return setUsersOption((prevOptions) => ({
+        offset: prevOptions.offset,
+        limit: prevOptions.limit,
+      }));
+    }
+
+    return setUsersOption((prevOptions) => ({
       offset: prevOptions.offset + 10,
       limit: prevOptions.limit + 10,
     }));
-  };
-
-  console.log(userList);
+  }, [userList]);
 
   useEffect(() => {
-    if (userList) {
+    if (userList && userList.length !== 0) {
       setAllUserList((prevList) => [...prevList, ...userList]);
     }
   }, [userList]);
 
   return (
     <StyledWrapper>
-      <UserSearchForm />
+      {/* <UserSearchForm /> */}
       <UserList
+        isLoading={isLoading}
+        isEnd={userList?.length === 0}
         userList={allUserList}
-        onlineUserLIst={onlineUserList || []}
+        onlineUserList={onlineUserList || []}
+        loadMoreUsers={loadMoreUsers}
       />
     </StyledWrapper>
   );

--- a/src/Components/UserManager/index.tsx
+++ b/src/Components/UserManager/index.tsx
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import UserList from './UserList';
+import UserSearchForm from './UserSearchForm';
+import StyledWrapper from './style';
+import { getOnlineUsers, getUsers } from '@/Services/User';
+import { UserType } from '@/Types/UserType';
+
+const UserManager = () => {
+  const [usersOption, setUsersOption] = useState({ offset: 0, limit: 10 });
+  const [allUserList, setAllUserList] = useState<UserType[]>([]);
+
+  const { data: userList } = useQuery({
+    queryKey: ['USER_LIST', usersOption.offset, usersOption.limit],
+    queryFn: () => getUsers(usersOption),
+  });
+
+  const { data: onlineUserList, isFetching } = useQuery({
+    queryKey: ['ONLINE_USER_LIST'],
+    queryFn: getOnlineUsers,
+    refetchInterval: 2000,
+  });
+
+  const loadMoreUsers = () => {
+    setUsersOption((prevOptions) => ({
+      offset: prevOptions.offset + 10,
+      limit: prevOptions.limit + 10,
+    }));
+  };
+
+  console.log(userList);
+
+  useEffect(() => {
+    if (userList) {
+      setAllUserList((prevList) => [...prevList, ...userList]);
+    }
+  }, [userList]);
+
+  return (
+    <StyledWrapper>
+      <UserSearchForm />
+      <UserList
+        userList={allUserList}
+        onlineUserLIst={onlineUserList || []}
+      />
+    </StyledWrapper>
+  );
+};
+
+export default UserManager;

--- a/src/Components/UserManager/index.tsx
+++ b/src/Components/UserManager/index.tsx
@@ -44,7 +44,6 @@ const UserManager = () => {
    * @returns {void} 반환값 없음
    */
   const loadMoreUsers = useCallback(() => {
-    console.log('렌더링');
     if (!userList || userList.length === 0) {
       return setUsersOption((prevOptions) => ({
         offset: prevOptions.offset,

--- a/src/Components/UserManager/style.ts
+++ b/src/Components/UserManager/style.ts
@@ -8,6 +8,11 @@ const StyledWrapper = styled.section`
   border-left: 1px solid ${({ theme }) => theme.colors.border};
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
+
+  @media ${({ theme }) => theme.device.laptop} {
+    display: none;
+  }
 `;
 
 export default StyledWrapper;

--- a/src/Components/UserManager/style.ts
+++ b/src/Components/UserManager/style.ts
@@ -2,15 +2,12 @@ import styled from 'styled-components';
 
 const StyledWrapper = styled.section`
   width: 30rem;
-  height: 100vh;
-  background-color: pink;
-  padding: ${({ theme }) => theme.size.small};
-  border-left: 1px solid #ddd;
-
+  height: 100%;
+  padding: 0 0.1rem 0 0;
+  background-color: ${({ theme }) => theme.colors.background};
+  border-left: 1px solid ${({ theme }) => theme.colors.border};
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: ${({ theme }) => theme.size.small};
 `;
 
 export default StyledWrapper;

--- a/src/Components/UserManager/style.ts
+++ b/src/Components/UserManager/style.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+const StyledWrapper = styled.section`
+  width: 30rem;
+  height: 100vh;
+  background-color: pink;
+  padding: ${({ theme }) => theme.size.small};
+  border-left: 1px solid #ddd;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${({ theme }) => theme.size.small};
+`;
+
+export default StyledWrapper;

--- a/src/Constants/queryKeys.ts
+++ b/src/Constants/queryKeys.ts
@@ -1,0 +1,6 @@
+const QUERY_KEYS = {
+  USER_LIST: 'userList',
+  ONLINE_USER_LIST: 'onlineUserList',
+};
+
+export default QUERY_KEYS;

--- a/src/Pages/HomePage/index.tsx
+++ b/src/Pages/HomePage/index.tsx
@@ -16,11 +16,6 @@ import {
   StyledLeftContainer,
   StyledMainContentContainer,
   StyledPostCardList,
-  StyledRightContainer,
-  StyledUserCardWrapper,
-  StyledUserInfoContainer,
-  StyledUserList,
-  StyledUserName,
   StyledWrapper,
 } from './style';
 import Button from '@/Components/Base/Button';
@@ -30,12 +25,10 @@ import { ChannelType } from '@/Types/ChannelType';
 import channels from '@/Constants/Channels';
 import { getUsers } from '@/Services/User';
 import { UserType } from '@/Types/UserType';
-import SearchBar from '@/Components/Common/SearchBar';
-import Avatar from '@/Components/Base/Avatar';
-import Badge from '@/Components/Base/Badge';
 import { getPostByChannel } from '@/Services/Post';
 import { PostType } from '@/Types/PostType';
 import PostCard from '@/Components/Common/PostCard';
+import UserManager from '@/Components/UserManager';
 
 const HomePage = () => {
   const { colors, size } = useTheme();
@@ -254,42 +247,7 @@ const HomePage = () => {
             ))}
           </StyledPostCardList>
         </StyledMainContentContainer>
-        {/* 유저 목록 네비바 */}
-        <StyledRightContainer>
-          {/* 검색바 */}
-          <SearchBar
-            onChangehandler={handleChangeSearch}
-            className="user-search"
-          />
-          {/* 유저 리스트 */}
-          <StyledUserList>
-            {(searchKeyword || searchedUserList.length !== 0
-              ? searchedUserList
-              : userList
-            ).map((user) => {
-              return (
-                <StyledUserCardWrapper key={user._id}>
-                  <Avatar
-                    src={user.coverImage || ''}
-                    className="user-avatar"
-                    size={30}
-                  >
-                    {!user.isOnline && (
-                      <Badge
-                        position="rightBottom"
-                        backgroundColor={colors.online}
-                        style={{ border: `1px solid ${colors.background}` }}
-                      />
-                    )}
-                  </Avatar>
-                  <StyledUserInfoContainer>
-                    <StyledUserName>{user.fullName}</StyledUserName>
-                  </StyledUserInfoContainer>
-                </StyledUserCardWrapper>
-              );
-            })}
-          </StyledUserList>
-        </StyledRightContainer>
+        <UserManager />
       </StyledWrapper>
     </>
   );

--- a/src/Pages/HomePage/style.ts
+++ b/src/Pages/HomePage/style.ts
@@ -65,7 +65,6 @@ export const StyledPostCardList = styled.div`
 
 export const StyledRightContainer = styled.div`
   display: flex;
-  padding: 1rem;
   flex-direction: column;
   position: relative;
   height: 100%;


### PR DESCRIPTION
## ✨ 반영 브랜치
`feature/getUserList` -> `dev`

## 📝 설명
limit, offset을 상태로 관리하여 사용자 목록을 불러와 실제로 보여질 상태 배열에 지속적으로 저장

옵저버 라이브러리를 이용하여 limit, offset을 10씩 증가

실시간 사용자 목록을 2초 간격마다 불러와서 현재 보여질 사용자 목록을 비교

![image](https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/assets/87266785/9ad430a6-236e-489b-9b09-ce518e7fc908)

## ✅ 변경 사항
- [x] 옵저버 라이브러리 "react-intersection-observer": "^9.5.3" 설치
- [x] 실시간 사용자 목록 reftchInterver 옵션 2초로 지정
- [x] 사용자 이미지가 없는 경우 일단 defaultImage 임시로 활용

## 💬 PR 포인트 & 질문사항
- SearchBar 컴포넌트 위치 조정이 좀 잘 안돼서 일단 조회부터 진행했습니다. SearchBar 수정되면 검색 구현 마무리 하겠습니다.
- 스크롤 바 색을 일단 검정색으로 했는데 먼가 마음에 들진 않네요,,
