### PR TITLE
Feat: Alert 컴포넌트 메세지 크기 props 추가

### DIFF
--- a/src/Components/Common/Alert/index.tsx
+++ b/src/Components/Common/Alert/index.tsx
@@ -1,6 +1,10 @@
 import Button from '@/Components/Base/Button';
 import Modal from '../Modal';
-import { StyledAlertWrapper, StyledButtonWrapper } from './style';
+import {
+  StyledAlertWrapper,
+  StyledButtonWrapper,
+  StyledMessage,
+} from './style';
 import { AlertPropsType } from './type';
 
 /**
@@ -13,6 +17,7 @@ const Alert = ({
   width = 20,
   height = 15,
   message,
+  fontSize = 1,
   confirmContent = 'OK',
   cancleContent = 'CANCEL',
   mode = 'alert',
@@ -41,7 +46,7 @@ const Alert = ({
       onChangeOpen={onChangeOpen}
     >
       <StyledAlertWrapper>
-        <div>{message}</div>
+        <StyledMessage $fontSize={fontSize}>{message}</StyledMessage>
         <StyledButtonWrapper>
           <Button
             height="30"

--- a/src/Components/Common/Alert/style.ts
+++ b/src/Components/Common/Alert/style.ts
@@ -16,3 +16,7 @@ export const StyledButtonWrapper = styled.div`
   justify-content: center;
   gap: 10px;
 `;
+
+export const StyledMessage = styled.div<{ $fontSize: number }>`
+  font-size: ${(props) => props.$fontSize}rem;
+`;

--- a/src/Components/Common/Alert/type.ts
+++ b/src/Components/Common/Alert/type.ts
@@ -4,6 +4,7 @@ export interface AlertPropsType extends HTMLAttributes<HTMLDivElement> {
   width?: number;
   height?: number;
   message: string;
+  fontSize?: number;
   confirmContent?: string;
   cancleContent?: string;
   mode?: 'alert' | 'confirm';


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/fixAlert` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
- Alert 컴포넌트의 메세지 크기를 조절할 수 있는 `fontSize` props를 추가했습니다.
- 단위는 rem입니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] Alert에 fontSize props 추가

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
.


