### PR TITLE
Feat: Modal 다크모드 props 추가

### DIFF
--- a/src/Components/Common/Modal/index.tsx
+++ b/src/Components/Common/Modal/index.tsx
@@ -1,5 +1,6 @@
 import { MouseEvent, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import { useTheme } from 'styled-components';
 import { ModalPropsType } from './type';
 import {
   StyledModalWrapper,
@@ -25,6 +26,7 @@ const Modal = ({
   onChangeOpen,
 }: ModalPropsType) => {
   const modalBgRef = useRef(null);
+  const theme = useTheme();
 
   /**
    * 모달 바깥 배경을 클릭하면 currentTarget를 확인후
@@ -47,6 +49,8 @@ const Modal = ({
         height={height}
         $borderRadius={borderRadius}
         $flexDirection={flexDirection}
+        $backgroundColor={theme.colors.background}
+        $color={theme.colors.text}
       >
         {children}
       </StyledModalContainer>

--- a/src/Components/Common/Modal/style.ts
+++ b/src/Components/Common/Modal/style.ts
@@ -25,7 +25,9 @@ export const StyledModalContainer = styled.div<StyledModalContainerType>`
   height: ${(props) => props.height}%;
   display: flex;
   z-index: 10;
-  background: white;
+  background: ${(props) => props.$backgroundColor};
+  border: 1px solid white;
+  color: ${(props) => props.$color};
   overflow: hidden;
   border-radius: ${(props) => props.$borderRadius}rem;
   ${(props) =>

--- a/src/Components/Common/Modal/type.ts
+++ b/src/Components/Common/Modal/type.ts
@@ -14,4 +14,6 @@ export interface StyledModalContainerType
   height: number;
   $borderRadius: number;
   $flexDirection: 'row' | 'column';
+  $backgroundColor: string;
+  $color: string;
 }


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/fixModal3` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
- Modal에 다크모드를 위한 옵션을 추가했습니다.
- 다크모드 적용시 border, text는 white, background는 black 적용했습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] Modal props 추가

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- light모드일 경우에도 border: white로 두었는데 문제 없겠죠..?


