### PR TITLE
Refactor: DropDown 컴포넌트 리팩토링

### DIFF
--- a/src/Components/Common/DropDown/index.tsx
+++ b/src/Components/Common/DropDown/index.tsx
@@ -36,6 +36,7 @@ const DropDown = forwardRef(
       optionProps,
       itemProps,
       labelProps,
+      isShow,
       ...props
     }: DropDownProps,
     ref: ForwardedRef<HTMLDivElement>,
@@ -60,6 +61,7 @@ const DropDown = forwardRef(
     return (
       <StyledDropDown
         ref={ref}
+        $isShow={isShow || true}
         onMouseEnter={() => setIsOpen(true)}
         onMouseLeave={() => setIsOpen(false)}
         {...props}
@@ -74,33 +76,47 @@ const DropDown = forwardRef(
             {label}
           </StyledLabel>
         )}
-        <StyledDropDownButton
-          onClick={() => setIsOpen(!isOpen)}
-          $width={width || '16rem'}
-          $height={height || '4rem'}
-          $backgroundColor={backgroundColor || theme.colors.background}
-          $textColor={textColor || theme.colors.text}
-          $textSize={textSize || theme.size.medium}
-          {...buttonProps}
-        >
-          {selectedOption}
-          {selectedOption === '선택 없음' ? (
-            <Icon
-              name="expand_circle_down"
-              isFill
-              onClick={() => handleSelect(selectedOption)}
-              style={{ color: textColor }}
-            />
-          ) : (
-            <Icon
-              name="cancel"
-              isFill
-              onClick={handleCancel}
-              style={{ color: textColor }}
-            />
-          )}
-        </StyledDropDownButton>
 
+        {children ? (
+          <StyledDropDownButton
+            onClick={() => setIsOpen(!isOpen)}
+            $width={width || '4rem'}
+            $height={height || '4rem'}
+            $backgroundColor={backgroundColor || theme.colors.background}
+            $textColor={textColor || theme.colors.text}
+            $textSize={textSize || theme.size.medium}
+            {...buttonProps}
+          >
+            {children}
+          </StyledDropDownButton>
+        ) : (
+          <StyledDropDownButton
+            onClick={() => setIsOpen(!isOpen)}
+            $width={width || '16rem'}
+            $height={height || '4rem'}
+            $backgroundColor={backgroundColor || theme.colors.background}
+            $textColor={textColor || theme.colors.text}
+            $textSize={textSize || theme.size.medium}
+            {...buttonProps}
+          >
+            {selectedOption}
+            {selectedOption === '선택 없음' ? (
+              <Icon
+                name="expand_circle_down"
+                isFill
+                onClick={() => handleSelect(selectedOption)}
+                style={{ color: textColor }}
+              />
+            ) : (
+              <Icon
+                name="cancel"
+                isFill
+                onClick={handleCancel}
+                style={{ color: textColor }}
+              />
+            )}
+          </StyledDropDownButton>
+        )}
         {isOpen && (
           <StyledDropDownOption
             $width={width || '16rem'}

--- a/src/Components/Common/DropDown/style.ts
+++ b/src/Components/Common/DropDown/style.ts
@@ -5,9 +5,9 @@ import {
   StyledLabelProp,
 } from './type';
 
-export const StyledDropDown = styled.div`
+export const StyledDropDown = styled.div<{ $isShow: boolean }>`
   position: relative;
-  display: inline-block;
+  display: ${(props) => (props.$isShow ? 'inline-block' : 'none')};
 `;
 
 export const StyledLabel = styled.span<StyledLabelProp>`

--- a/src/Components/Common/DropDown/type.ts
+++ b/src/Components/Common/DropDown/type.ts
@@ -14,6 +14,7 @@ export interface DropDownProps {
   itemBackgroundColor?: string;
   itemTextColor?: string;
   itemTextSize?: string;
+  isShow?: boolean;
   onSelect?: (selected: string) => void;
 
   buttonProps?: HTMLAttributes<HTMLElement>;


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
드롭다운 컴포넌트를 리팩토링하였습니다.

![Jan-08-2024 17-43-41](https://github.com/prgrms-fe-devcourse/FEDC5_STYLED_sehee/assets/95916813/d862f135-87ed-4033-934b-2d2de9a0401a)


1. 기본 디자인을 사용하고자 하는 경우

```
          <DropDown options={['1', '2', '3']} />
```

2. children과 inline-styling을 통한 커스텀 디자인

```
          <DropDown
            options={['1', '2', '3']}
            buttonProps={{
              style: {
                justifyContent: 'center',
                border: 'none',
              },
            }}
          >
            <Icon name="account_circle" />
          </DropDown>
```
<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `IsShow` 프롭을 통해 드롭다운을 토글 형식으로 렌더링할 수 있습니다. 생략 가능하며, 기본값은 true입니다.
- [x] `children`에 원하는 요소(아이콘, 이미지 등)를 담아 드롭다운 디자인을 커스텀할 수 있습니다. {...buttonProps}를 통해 Inline-style을 함께 적용해주세요.
