### PR TITLE
Feat: 메인 페이지 포스트 무한 스크롤 구현

### DIFF
--- a/src/Pages/HomePage/index.tsx
+++ b/src/Pages/HomePage/index.tsx
@@ -35,6 +35,7 @@ import PostCard from '@/Components/Common/PostCard';
 import UserManager from '@/Components/UserManager';
 import useAuthUserStore from '@/Stores/AuthUser';
 import { checkAuth } from '@/Services/Auth';
+import filterSuperUser from '@/Utils/checkSuperUser';
 
 const HomePage = () => {
   const { colors, size } = useTheme();
@@ -98,13 +99,11 @@ const HomePage = () => {
    */
   const fetchUserList = async () => {
     const userData = await getUsers();
-
     // 관리자 계정 제외 필터링
-    const filteredUserList = userData?.filter(
-      ({ role }) => role !== 'SuperAdmin',
-    );
 
-    return filteredUserList && setUserList(filteredUserList);
+    const withoutSuperUser = userData && filterSuperUser(userData);
+
+    return withoutSuperUser && setUserList(withoutSuperUser);
   };
 
   /**

--- a/src/Pages/HomePage/index.tsx
+++ b/src/Pages/HomePage/index.tsx
@@ -265,19 +265,17 @@ const HomePage = () => {
           {/* 포스트 카드 리스트 */}
           {postList.length !== 0 ? (
             <StyledPostCardList>
-              {postList.length !== 0
-                ? postList.map((post) => (
-                    <PostCard
-                      key={post._id}
-                      imageUrl={post.image || ''}
-                      content={post.title || ''}
-                      authorName={post.author.fullName || ''}
-                      authorThumbnail=""
-                      isFollower
-                      isLike
-                    />
-                  ))
-                : null}
+              {postList.map((post) => (
+                <PostCard
+                  key={post._id}
+                  imageUrl={post.image || ''}
+                  content={post.title || ''}
+                  authorName={post.author.fullName || ''}
+                  authorThumbnail=""
+                  isFollower
+                  isLike
+                />
+              ))}
               <StyledObserver ref={refInView} />
             </StyledPostCardList>
           ) : (

--- a/src/Pages/HomePage/index.tsx
+++ b/src/Pages/HomePage/index.tsx
@@ -17,6 +17,7 @@ import {
   StyledHeaderContainer,
   StyledLeftContainer,
   StyledMainContentContainer,
+  StyledNoPost,
   StyledPostCardList,
   StyledWrapper,
 } from './style';
@@ -54,6 +55,8 @@ const HomePage = () => {
    */
   const handleClickChannel = (e: MouseEvent<HTMLButtonElement>) => {
     const channelId = e.currentTarget.dataset.id;
+
+    if (channelId !== currentChannelId) setPostList([]);
 
     setPostOffset(0);
 
@@ -263,19 +266,23 @@ const HomePage = () => {
         </StyledLeftContainer>
         <StyledMainContentContainer>
           {/* 포스트 카드 리스트 */}
-          <StyledPostCardList>
-            {postList.map((post) => (
-              <PostCard
-                key={post._id}
-                imageUrl={post.image || ''}
-                content={post.title || ''}
-                authorName={post.author.fullName || ''}
-                authorThumbnail=""
-                isFollower
-                isLike
-              />
-            ))}
-          </StyledPostCardList>
+          {postList.length !== 0 ? (
+            <StyledPostCardList>
+              {postList.map((post) => (
+                <PostCard
+                  key={post._id}
+                  imageUrl={post.image || ''}
+                  content={post.title || ''}
+                  authorName={post.author.fullName || ''}
+                  authorThumbnail=""
+                  isFollower
+                  isLike
+                />
+              ))}
+            </StyledPostCardList>
+          ) : (
+            <StyledNoPost>페이지가 없습니다.</StyledNoPost>
+          )}
         </StyledMainContentContainer>
         <UserManager />
       </StyledWrapper>

--- a/src/Pages/HomePage/index.tsx
+++ b/src/Pages/HomePage/index.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import {
   StyledCategoryList,
   StyledCategoryTitle,
@@ -35,7 +36,8 @@ import { checkAuth } from '@/Services/Auth';
 
 const HomePage = () => {
   const { colors, size } = useTheme();
-  const { setAuthUser } = useAuthUserStore();
+  const navigate = useNavigate();
+  const { user: authUser, setAuthUser } = useAuthUserStore();
 
   const [channelList, setChannelList] = useState<ChannelType[]>([]);
   const [userList, setUserList] = useState<UserType[]>([]);
@@ -155,6 +157,15 @@ const HomePage = () => {
   );
 
   useEffect(() => {
+    if (!authUser._id) {
+      // eslint-disable-next-line no-alert
+      if (window.confirm('님 로그인 안됨. 로그인 하실꺼임?')) {
+        navigate('/login');
+      }
+    }
+  }, [authUser._id, navigate]);
+
+  useEffect(() => {
     if (channelList.length === 0) fetchChannelList();
     if (userList.length === 0) fetchUserList();
 
@@ -183,19 +194,21 @@ const HomePage = () => {
           <StyledCategoryTitleContainer>
             <StyledCategoryTitle>카테고리</StyledCategoryTitle>
             {/* 카테고리 채널 추가 버튼 */}
-            <Button
-              width={size.large}
-              height={size.large}
-              borderRadius="0.5rem"
-              textSize={size.medium}
-              backgroundColor={colors.background}
-              hoverBackgroundColor={colors.backgroundGrey}
-            >
-              <Icon
-                name="add"
-                style={{ color: `grey`, fontSize: `${size.large}` }}
-              />
-            </Button>
+            {authUser.role === 'SuperAdmin' && (
+              <Button
+                width={size.large}
+                height={size.large}
+                borderRadius="0.5rem"
+                textSize={size.medium}
+                backgroundColor={colors.background}
+                hoverBackgroundColor={colors.backgroundGrey}
+              >
+                <Icon
+                  name="add"
+                  style={{ color: `grey`, fontSize: `${size.large}` }}
+                />
+              </Button>
+            )}
           </StyledCategoryTitleContainer>
           {/* 채널 버튼 리스트 */}
           <StyledCategoryList>

--- a/src/Pages/HomePage/index.tsx
+++ b/src/Pages/HomePage/index.tsx
@@ -119,7 +119,7 @@ const HomePage = () => {
         limit: 10,
       });
 
-      if (postData?.length !== 0 && postData) {
+      if (postData?.length !== 0) {
         const newPostList = postData && [...postList, ...postData];
 
         setPostOffset(postOffset + 10);

--- a/src/Pages/HomePage/style.ts
+++ b/src/Pages/HomePage/style.ts
@@ -20,6 +20,10 @@ export const StyledLeftContainer = styled.div`
   align-items: center;
   border-right: 0.1rem solid #ddd;
   gap: 1rem;
+
+  @media ${({ theme }) => theme.device.tablet} {
+    display: none;
+  }
 `;
 
 export const StyledCategoryTitleContainer = styled.div`

--- a/src/Pages/HomePage/style.ts
+++ b/src/Pages/HomePage/style.ts
@@ -50,6 +50,8 @@ export const StyledCategoryTitle = styled.div`
 `;
 
 export const StyledMainContentContainer = styled.div`
+  display: flex;
+  align-items: center;
   padding: 1rem;
   width: calc(100% - 60rem);
   height: 100%;
@@ -65,6 +67,13 @@ export const StyledPostCardList = styled.div`
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
+`;
+
+export const StyledNoPost = styled.div`
+  width: 100%;
+  height: fit-content;
+  text-align: center;
+  font-size: ${({ theme }) => theme.size.large};
 `;
 
 export const StyledRightContainer = styled.div`

--- a/src/Pages/HomePage/style.ts
+++ b/src/Pages/HomePage/style.ts
@@ -51,6 +51,7 @@ export const StyledCategoryTitle = styled.div`
 
 export const StyledMainContentContainer = styled.div`
   display: flex;
+  flex-direction: column;
   align-items: center;
   padding: 1rem;
   width: calc(100% - 60rem);
@@ -67,6 +68,12 @@ export const StyledPostCardList = styled.div`
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
+`;
+
+export const StyledObserver = styled.div`
+  width: 100%;
+  flex-basis: 1rem;
+  flex-shrink: 0;
 `;
 
 export const StyledNoPost = styled.div`

--- a/src/Utils/checkSuperUser.ts
+++ b/src/Utils/checkSuperUser.ts
@@ -1,0 +1,9 @@
+import { UserType } from '@/Types/UserType';
+
+const filterSuperUser = (userData: UserType[]) => {
+  const filtereduserList = userData.filter(({ role }) => role !== 'SuperAdmin');
+
+  return filtereduserList;
+};
+
+export default filterSuperUser;


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/mainPagePostScroll` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
메인 페이지 채널 클릭 시 포스트의 무한 스크롤을 구했습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] react-intersection-observer 라이브러리를 사용하여 10개 씩 포스트가 업데이트되도록 구현
- [x] 좌측 네비바 반응형 디자인으로 태블릿 사이즈일 때 숨겨지게 구현 
- [x] 다른 채널을 클릭하면 포스트 리스트 초기화되도록 구현
- [x] 포스트가 없을 경우 포스트가 없다는 페이지 표시하도록 구현
- [x] 관리자 계정이 아닐 경우 채널 생성 버튼 숨기도록 구현

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 메인페이지에서 로그인 안했을 경우 로그인 확인 창 보이도록 대략적으로 해볼려고 했는데 잘 안되네요...
그냥 기존 하기로 했던 것처럼 메인페이지에서 인증된 사용자만 수행할 수 있는 기능을 실행하려고 하면 로그인 권유 및 로그인 창으로 이동하는 방식으로 구현하는 것이 맞을 거 같습니다.
