### PR TITLE
Fix: User Card 이름 및 아바타 클릭 오류 및 다이렉트 메시지 버그 수정

### DIFF
--- a/src/Components/Common/UserCard/index.tsx
+++ b/src/Components/Common/UserCard/index.tsx
@@ -60,7 +60,12 @@ const UserCard = forwardRef(
      * UserCard 내 요소 클릭 시 클릭이벤트 전달용 함수
      * 어떻게 사용 및 확장할지는 추후 결정해야 할듯
      */
+
     const handleClick = (e: MouseEvent<HTMLDivElement>) => {
+      if (onClickUser) {
+        onClickUser();
+        return;
+      }
       if (onClick && e.target === e.currentTarget) {
         onClick(e);
       }
@@ -88,7 +93,7 @@ const UserCard = forwardRef(
           className="user-avatar"
           size={avatarSize}
           // @TODO: 이부분 원래 handleClick 사용되던 곳. 수정해야합니다!
-          onClick={onClickUser}
+          onClick={handleClick}
           style={{
             cursor: 'pointer',
             minWidth: `${avatarSize}px`,
@@ -113,7 +118,7 @@ const UserCard = forwardRef(
               userNameWeight || (!isRead ? fontWeight.black : fontWeight.medium)
             }
             // @TODO: 이부분 원래 handleClick 사용되던 곳. 수정해야합니다!
-            onClick={onClickUser}
+            onClick={handleClick}
           >
             {userName}
           </StyledUserName>

--- a/src/Components/DirectMessage/ConversationList/index.tsx
+++ b/src/Components/DirectMessage/ConversationList/index.tsx
@@ -54,6 +54,7 @@ const ConversationList = ({
           userName={loginUser.fullName}
           userNameSize="1.5rem"
           onClick={handleClickMyName}
+          className="conversation-list-header"
         />
         <Button
           width="3rem"

--- a/src/Components/DirectMessage/ConversationList/style.ts
+++ b/src/Components/DirectMessage/ConversationList/style.ts
@@ -25,6 +25,15 @@ export const StyledHeader = styled.div`
     color: transparent;
     -webkit-background-clip: text;
   }
+
+  .conversation-list-header {
+    flex-grow: 0;
+    & > :nth-child(2) {
+      h1 {
+        display: inline;
+      }
+    }
+  }
 `;
 
 export const StyledBody = styled.div`

--- a/src/Hooks/useResize/index.ts
+++ b/src/Hooks/useResize/index.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useTheme } from 'styled-components';
 
 const useResize = () => {
-  const [isMobileSize, setIsMobileSize] = useState(false);
+  const [isMobileSize, setIsMobileSize] = useState(window.innerWidth < 768);
   const { device } = useTheme();
 
   useEffect(() => {

--- a/src/Pages/DetailPage/PostDetailModal/index.tsx
+++ b/src/Pages/DetailPage/PostDetailModal/index.tsx
@@ -48,6 +48,7 @@ import { useDisLikeById, useLikeById } from '@/Hooks/Api/Like';
 import { useFollowByUserId, useUnfollowByUserId } from '@/Hooks/Api/Follow';
 import { useCreateComment, useDeleteComment } from '@/Hooks/Api/Comment';
 import { useCreateNotification } from '@/Hooks/Api/Notification';
+import useMessageReceiver from '@/Stores/MessageReceiver';
 
 const PostDetailModal = ({
   postLike,
@@ -63,6 +64,7 @@ const PostDetailModal = ({
   const { colors, size } = useTheme();
   const { postId } = useParams();
   const { user: authUser } = useAuthUserStore();
+  const { setReceiver } = useMessageReceiver();
 
   const commentInputRef = useRef<HTMLInputElement>(null);
 
@@ -127,7 +129,14 @@ const PostDetailModal = ({
    * DM 버튼 클릭 동작 함수
    */
   const handleClickDMBtn = () => {
-    navigate('/directmessage');
+    if (postDetailData) {
+      if (postDetailData.author._id !== authUser._id) {
+        setReceiver(postDetailData?.author);
+      } else {
+        setReceiver(null);
+      }
+      navigate('/directmessage');
+    }
   };
 
   /**

--- a/src/Pages/DirectMessagePage/index.tsx
+++ b/src/Pages/DirectMessagePage/index.tsx
@@ -61,7 +61,7 @@ const DirectMessagePage = () => {
       {!isMobileSize && (
         <>
           {conversationList}
-          {!receiver || !isClickedUserCard ? (
+          {!receiver ? (
             <StyledDiv>친구에게 메시지를 보내보세요!</StyledDiv>
           ) : (
             messageList


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/fixDirectAndUserCardClick` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
User Card 내 닉네임과 아바타 클릭 이벤트에 대한 오류를 해결하고
포스트 상세페이지에서 다이렉트 메시지 페이지로 넘어갈 때 receiver가 유지 안되는 버그를 해결했습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] UserCard 내 click 이벤트 Props 조건 일부 수정
- [x] 포스트 상세 페이지 내 다이렉트 메시지 버튼 누를 때 setReceiver 로직 추가

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 추가 에러 사항은 현주님이 추가 PR할 예정입니다.
