### PR TITLE
Fix: 로그인 페이지 뒤로가기 버튼 2번 클릭 시 이동하는 버그 수정

### DIFF
--- a/src/Components/Common/Header/HeaderTab/LoginButton/index.tsx
+++ b/src/Components/Common/Header/HeaderTab/LoginButton/index.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import Button from '@/Components/Base/Button';
 
-const LoginButton = ({ ...props }) => {
+const LoginButton = () => {
   return (
     <Link to="/login">
       <Button
@@ -12,7 +12,6 @@ const LoginButton = ({ ...props }) => {
         key="login"
         borderRadius="1rem"
         style={{ marginRight: '1rem' }}
-        {...props}
       >
         로그인
       </Button>

--- a/src/Components/Common/Header/HeaderTab/index.tsx
+++ b/src/Components/Common/Header/HeaderTab/index.tsx
@@ -182,7 +182,7 @@ const HeaderTab = () => {
         </StyledButtonContainer>
 
         {!isAuthUser ? (
-          <LoginButton onClick={() => navigate('/login')} />
+          <LoginButton />
         ) : (
           <>
             <StyledButtonContainer>


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/fixLoginPageBackButton` -> `dev`

## 📝 설명
로그인 페이지 뒤로가기 버튼 클릭 시 2번 클릭해야 동작하는 버그 수정했습니다.

히스토리에 로그인 페이지 이동이 2번 동작

## ✅ 변경 사항
- [x] HeaderTab 클릭 이벤트 제거
- [x] LoginButton 불필요한 props 제거

