### PR TITLE
Refactor: 다이렉트 메세지 페이지 QA 수정사항 반영

### DIFF
--- a/src/Components/Common/UserCard/index.tsx
+++ b/src/Components/Common/UserCard/index.tsx
@@ -8,6 +8,7 @@ import {
   StyledUserDetail,
   StyledUserReadContainer,
   StyledUserFollowContainer,
+  StyledUserDetailText,
 } from './style';
 import { UserCardProps } from './type';
 import Badge from '@/Components/Base/Badge';
@@ -92,7 +93,6 @@ const UserCard = forwardRef(
           src={coverImageUrl || ''}
           className="user-avatar"
           size={avatarSize}
-          // @TODO: 이부분 원래 handleClick 사용되던 곳. 수정해야합니다!
           onClick={handleClick}
           style={{
             cursor: 'pointer',
@@ -117,19 +117,24 @@ const UserCard = forwardRef(
             fontWeight={
               userNameWeight || (!isRead ? fontWeight.bold : fontWeight.medium)
             }
-            // @TODO: 이부분 원래 handleClick 사용되던 곳. 수정해야합니다!
             onClick={handleClick}
           >
             {userName}
           </StyledUserName>
           {userDetail && (
-            <StyledUserDetail
-              fontSize={userDetailSize || '1.3rem'}
-              fontWeight={!isRead ? fontWeight.black : fontWeight.regular}
-              onClick={handleClick}
-            >
-              {userDetail}
-              {mode === 'chat' && <div>{date}</div>}
+            <StyledUserDetail>
+              <StyledUserDetailText
+                fontSize={userDetailSize || '1.3rem'}
+                fontWeight={!isRead ? fontWeight.black : fontWeight.regular}
+                onClick={handleClick}
+              >
+                {userDetail}
+              </StyledUserDetailText>
+              {mode === 'chat' && (
+                <StyledUserDetailText onClick={handleClick}>
+                  {date}
+                </StyledUserDetailText>
+              )}
             </StyledUserDetail>
           )}
         </StyledUserInfoContainer>

--- a/src/Components/Common/UserCard/style.ts
+++ b/src/Components/Common/UserCard/style.ts
@@ -38,12 +38,15 @@ export const StyledUserInfoContainer = styled.div`
 export const StyledUserName = styled.h1<StyledUserNameProps>`
   font-size: ${({ fontSize }) => fontSize};
   font-weight: ${({ fontWeight }) => fontWeight};
+  color: ${({ theme }) => theme.colors.text};
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 `;
 
-export const StyledUserDetail = styled.div<StyledUserDetailProps>`
+export const StyledUserDetail = styled.div``;
+
+export const StyledUserDetailText = styled.div<StyledUserDetailProps>`
   font-size: ${({ fontSize }) => fontSize};
   font-weight: ${({ fontWeight }) => fontWeight};
   color: #9f9f9f;

--- a/src/Components/Common/UserCard/type.ts
+++ b/src/Components/Common/UserCard/type.ts
@@ -38,6 +38,6 @@ export interface StyledUserNameProps {
 }
 
 export interface StyledUserDetailProps {
-  fontSize: string;
-  fontWeight: string;
+  fontSize?: string;
+  fontWeight?: string;
 }

--- a/src/Components/DirectMessage/ConversationList/type.ts
+++ b/src/Components/DirectMessage/ConversationList/type.ts
@@ -1,12 +1,6 @@
-import { ConversationType } from '@/Types/ConversationType';
 import { UserType } from '@/Types/UserType';
 
 export interface ConversationListProps {
-  setReceiver: (state: UserType | null) => void;
-  conversations: ConversationType[] | null | undefined;
-  isConversationsLoading: boolean;
-  conversationsRefetch: () => void;
   loginUser: Partial<UserType>;
-  setIsClickedUserCard?: (state: boolean) => void;
-  isMobileSize?: boolean;
+  isMobileSize: boolean;
 }

--- a/src/Components/DirectMessage/MessageList/index.tsx
+++ b/src/Components/DirectMessage/MessageList/index.tsx
@@ -42,11 +42,11 @@ const MessageList = ({
 
   const queryClient = useQueryClient();
   const {
-    isMessagesFetchedAfterMount,
-    messages,
-    isMessagesFetching,
-    isMessagesLoading,
-    messagesRefetch,
+    isFetchedAfterMount: isMessagesFetchedAfterMount,
+    data: messages,
+    isFetching: isMessagesFetching,
+    isLoading: isMessagesLoading,
+    refetch: messagesRefetch,
   } = useFetchMessages(receiver._id);
   const { mutateReadMessage } = useReadMessage();
 

--- a/src/Components/DirectMessage/MessageList/index.tsx
+++ b/src/Components/DirectMessage/MessageList/index.tsx
@@ -1,7 +1,9 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable no-underscore-dangle */
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
+import { useTheme } from 'styled-components';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   AlertContainer,
   MessageItemContainer,
@@ -13,39 +15,42 @@ import {
 import Input from '@/Components/Base/Input';
 import MessageItem from '../MessageItem';
 import { MessageListProps } from './type';
-import { useFetchMessages } from '@/Hooks/Api/Message';
-import { createMessage } from '@/Services/Message';
+import { useFetchMessages, useReadMessage } from '@/Hooks/Api/Message';
 import DirectMessageSkeleton from '../Skeleton';
-import { sendNotifications } from '@/Services/Notification';
 import Alert from '@/Components/Common/Alert';
 import UserCard from '@/Components/Common/UserCard';
 import Icon from '@/Components/Base/Icon';
 import Button from '@/Components/Base/Button';
+import QUERY_KEYS from '@/Constants/queryKeys';
+import useMessageReceiver from '@/Stores/MessageReceiver';
+import { createMessage } from '@/Services/Message';
+import { sendNotifications } from '@/Services/Notification';
 
 const MessageList = ({
-  isClickedUserCard,
-  setIsClickedUserCard,
   isMobileSize = false,
   receiver,
-  conversationsRefetch,
   loginUser,
 }: MessageListProps) => {
-  const { messages, isMessagesLoading, messagesRefetch } = useFetchMessages(
-    receiver._id,
-  );
-  const [isAlertOpen, setIsAlertOpen] = useState(false);
-  const scrollRef = useRef<HTMLDivElement | null>(null);
-  const inputRef = useRef<HTMLInputElement | null>(null);
   const navigator = useNavigate();
+  const { colors } = useTheme();
 
   const [isLoading, setIsLoading] = useState(true);
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
 
-  useEffect(() => {
-    setIsLoading(true);
-    setTimeout(() => {
-      setIsLoading(false);
-    }, 1000);
-  }, [receiver]);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const queryClient = useQueryClient();
+  const {
+    isMessagesFetchedAfterMount,
+    messages,
+    isMessagesFetching,
+    isMessagesLoading,
+    messagesRefetch,
+  } = useFetchMessages(receiver._id);
+  const { mutateReadMessage } = useReadMessage();
+
+  const { isClickedUserCard, setIsClickedUserCard } = useMessageReceiver();
 
   // 선택한 채팅방이 달라질 때마다 messages를 다시 가지고 온다.
   useEffect(() => {
@@ -54,12 +59,21 @@ const MessageList = ({
     }
   }, [receiver, messagesRefetch]);
 
-  // 메세지를 보낼 때마다 채팅창을 맨 아래로 스크롤을 고정 시킨다.
   useEffect(() => {
+    // 메세지를 보낼 때마다 채팅창을 맨 아래로 스크롤을 고정 시킨다.
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
+    // 처음 불러올 때는 조금 여유를 두고 로딩을 추가해준다.
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 500);
   }, [messages, isLoading]);
+
+  // messages가 새로 올 때 마다 읽음 처리 해준다.
+  useEffect(() => {
+    mutateReadMessage(receiver._id);
+  }, [messages]);
 
   const sendMessage = async () => {
     if (!inputRef || !inputRef.current) {
@@ -73,6 +87,7 @@ const MessageList = ({
     const content = inputRef.current.value.trim();
     inputRef.current.value = '';
 
+    // 상대방에게 메세지를 보낸다.
     const message = await createMessage({
       message: content,
       receiver: receiver._id,
@@ -97,8 +112,9 @@ const MessageList = ({
     }
 
     // 사이드바의 마지막 메시지와 현재 messages를 갱신
-    conversationsRefetch();
-    messagesRefetch();
+    queryClient.refetchQueries({
+      queryKey: [QUERY_KEYS.CONVERSATIONS, QUERY_KEYS.MESSAGES],
+    });
   };
 
   const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -115,13 +131,16 @@ const MessageList = ({
   };
 
   const handleClickBack = () => {
-    if (setIsClickedUserCard) {
-      setIsClickedUserCard(false);
-    }
+    setIsClickedUserCard(false);
   };
+
   return (
     <StyledContainer $isClickedUserCard={isClickedUserCard}>
-      {isLoading || isMessagesLoading || !messages || isAlertOpen ? (
+      {isLoading ||
+      (!isMessagesFetchedAfterMount && isMessagesFetching) ||
+      isMessagesLoading ||
+      !messages ||
+      isAlertOpen ? (
         <>
           <DirectMessageSkeleton.MessageList />
           {isAlertOpen && (
@@ -129,8 +148,8 @@ const MessageList = ({
               width={40}
               message={
                 <AlertContainer>
-                  <div>잠시 네트워크에 문제가 생겼습니다.</div>
-                  <div>다시 시도해주세요.</div>
+                  <div>메세지 전송 중 네트워크에 문제가 생겼습니다.</div>
+                  <div>새로고침 후 다시 시도해주세요.</div>
                 </AlertContainer>
               }
               onChangeOpen={setIsAlertOpen}
@@ -188,6 +207,7 @@ const MessageList = ({
                 backgroundColor: 'white',
                 padding: '1.5rem 3rem 1.5rem 3rem',
                 borderRadius: '3rem',
+                color: colors.black,
               }}
             />
             <Button

--- a/src/Components/DirectMessage/MessageList/style.ts
+++ b/src/Components/DirectMessage/MessageList/style.ts
@@ -65,7 +65,6 @@ export const StyledFooter = styled.div`
   bottom: 5%;
   gap: 1rem;
   align-items: center;
-  background-color: ${({ theme }) => theme.colors.background};
 
   .send-icon {
     display: flex;

--- a/src/Components/DirectMessage/MessageList/type.ts
+++ b/src/Components/DirectMessage/MessageList/type.ts
@@ -2,9 +2,6 @@ import { UserType } from '@/Types/UserType';
 
 export interface MessageListProps {
   receiver: UserType;
-  conversationsRefetch: () => void;
   loginUser: Partial<UserType>;
-  isClickedUserCard?: boolean;
-  setIsClickedUserCard?: (state: boolean) => void;
-  isMobileSize?: boolean;
+  isMobileSize: boolean;
 }

--- a/src/Components/DirectMessage/MessageModal/index.tsx
+++ b/src/Components/DirectMessage/MessageModal/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { useRef, useState } from 'react';
+import { useTheme } from 'styled-components';
 import Modal from '@/Components/Common/Modal';
 import { StyledBody, StyledContainer, StyledHeader } from './style';
 import Button from '@/Components/Base/Button';
@@ -10,23 +11,26 @@ import UserCard from '@/Components/Common/UserCard';
 import DirectMessageSkeleton from '../Skeleton';
 import { useSearchUsers } from '@/Hooks/Api/Search';
 import useDebouncedSearch from '@/Hooks/useDebouncedSearch';
+import useMessageReceiver from '@/Stores/MessageReceiver';
 
 const MessageModal = ({
-  setReceiver,
-  onChangeOpen,
   setIsModalOpen,
   loginUser,
   isMobileSize = false,
-  setIsClickedUserCard,
 }: MessageModalProps) => {
+  const { colors } = useTheme();
   const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const [isTyping, setIsTyping] = useState(false);
   const [selected, setSelected] = useState<UserType | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
+
   const { users, isUsersLoading } = useSearchUsers(
     searchQuery,
     loginUser?._id || '',
   );
-  const [isTyping, setIsTyping] = useState(false);
+
+  const { setReceiver, setIsClickedUserCard } = useMessageReceiver();
 
   // 디바운싱을 이용해 onChange 성능을 개선한다.
   const debouncedSearch = useDebouncedSearch({
@@ -52,7 +56,7 @@ const MessageModal = ({
 
   return (
     <Modal
-      onChangeOpen={onChangeOpen}
+      onChangeOpen={setIsModalOpen}
       height={60}
       width={isMobileSize ? 70 : 40}
     >
@@ -72,9 +76,9 @@ const MessageModal = ({
           ) : (
             users?.map((user) => (
               <UserCard
-                height="auto"
                 key={user._id}
                 mode="radio"
+                height="auto"
                 coverImageUrl={user.image}
                 avatarSize={40}
                 userName={user.fullName}
@@ -91,7 +95,11 @@ const MessageModal = ({
         <Button
           height="3rem"
           width="60%"
-          style={{ marginTop: '1rem' }}
+          style={{
+            marginRight: '1rem',
+            marginTop: '.5rem',
+            border: `1px solid ${colors.text}`,
+          }}
           onClick={() => handleClickButton()}
           isActive={!selected}
           disabled={!selected}

--- a/src/Components/DirectMessage/MessageModal/type.ts
+++ b/src/Components/DirectMessage/MessageModal/type.ts
@@ -1,10 +1,7 @@
 import { UserType } from '@/Types/UserType';
 
 export interface MessageModalProps {
-  onChangeOpen: (state: boolean) => void;
-  setReceiver: (state: UserType) => void;
   setIsModalOpen: (state: boolean) => void;
   loginUser: Partial<UserType>;
-  isMobileSize?: boolean;
-  setIsClickedUserCard: (state: boolean) => void;
+  isMobileSize: boolean;
 }

--- a/src/Components/DirectMessage/Skeleton/index.tsx
+++ b/src/Components/DirectMessage/Skeleton/index.tsx
@@ -1,5 +1,6 @@
 import Skeleton from '@/Components/Base/Skeleton';
 import {
+  HeaderContainer,
   MessageListContainer,
   MessageListParagraphWrapper,
   MessageListWrapper,
@@ -118,9 +119,22 @@ const UserCard = ({ length = 5 }: UserCardProps) => {
   );
 };
 
+const Header = () => {
+  return (
+    <HeaderContainer>
+      <Skeleton.Circle size="4rem" />
+      <Skeleton.Paragraph
+        line={1}
+        style={{ width: '70%', height: '100%' }}
+      />
+    </HeaderContainer>
+  );
+};
+
 const DirectMessageSkeleton = {
   MessageList,
   UserCard,
+  Header,
 };
 
 export default DirectMessageSkeleton;

--- a/src/Components/DirectMessage/Skeleton/style.ts
+++ b/src/Components/DirectMessage/Skeleton/style.ts
@@ -36,3 +36,10 @@ export const UserCardWrapper = styled.div`
   align-items: center;
   gap: 1rem;
 `;
+
+export const HeaderContainer = styled.div`
+  display: flex;
+  width: 100%;
+  gap: 1rem;
+  align-items: center;
+`;

--- a/src/Components/NotificationModal/NotificationItem/index.tsx
+++ b/src/Components/NotificationModal/NotificationItem/index.tsx
@@ -24,7 +24,7 @@ const NotificationItem = ({
   isSeen,
   onClose,
 }: Props) => {
-  const { setReceiver } = useMessageReceiver();
+  const { setReceiver, setIsClickedUserCard } = useMessageReceiver();
   const { mutateReadMessage } = useReadMessage();
   const navigate = useNavigate();
 
@@ -42,6 +42,7 @@ const NotificationItem = ({
     if (type === 'message') {
       onClose();
       setReceiver(author);
+      setIsClickedUserCard(true);
       mutateReadMessage(author._id);
       navigate('/directmessage');
     }

--- a/src/Components/Profile/ProfileInfo/UserProfileInfo/index.tsx
+++ b/src/Components/Profile/ProfileInfo/UserProfileInfo/index.tsx
@@ -12,7 +12,7 @@ import useFetchUser from '@/Hooks/Api/User';
 import { useReadMessage } from '@/Hooks/Api/Message';
 
 const UserProfileInfo = ({ name, user, isFollowing }: NameProps) => {
-  const { setReceiver } = useMessageReceiver();
+  const { setReceiver, setIsClickedUserCard } = useMessageReceiver();
   const { colors } = useTheme();
   const { userId } = useParams() || '';
   const { loginUserRefetch } = useCheckAuth();
@@ -40,6 +40,7 @@ const UserProfileInfo = ({ name, user, isFollowing }: NameProps) => {
   };
 
   const navigateDirectMessage = () => {
+    setIsClickedUserCard(true);
     setReceiver(user);
     mutateReadMessage(user._id);
   };

--- a/src/Hooks/Api/Message/index.ts
+++ b/src/Hooks/Api/Message/index.ts
@@ -29,28 +29,19 @@ export const useFetchConversations = () => {
 };
 
 export const useFetchMessages = (userId: string) => {
-  const { data, isFetching, isFetchedAfterMount, isLoading, refetch } =
-    useQuery<MessageType[] | null>({
-      queryKey: [QUERY_KEYS.MESSAGES],
-      queryFn: async () => {
-        const messages = await getMessages(userId);
-        return messages
-          ? messages.sort(
-              (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt),
-            )
-          : [];
-      },
-      refetchInterval: 2000,
-      enabled: !!userId,
-    });
-
-  return {
-    isMessagesFetchedAfterMount: isFetchedAfterMount,
-    messages: data,
-    isMessagesFetching: isFetching,
-    isMessagesLoading: isLoading,
-    messagesRefetch: refetch,
-  };
+  return useQuery<MessageType[] | null>({
+    queryKey: [QUERY_KEYS.MESSAGES],
+    queryFn: async () => {
+      const messages = await getMessages(userId);
+      return messages
+        ? messages.sort(
+            (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt),
+          )
+        : [];
+    },
+    refetchInterval: 2000,
+    enabled: !!userId,
+  });
 };
 
 export const useCreateMessage = (onError?: () => void) => {

--- a/src/Hooks/Api/Message/index.ts
+++ b/src/Hooks/Api/Message/index.ts
@@ -12,60 +12,67 @@ import { ConversationType } from '@/Types/ConversationType';
 import QUERY_KEYS from '@/Constants/queryKeys';
 
 export const useFetchConversations = () => {
-  const { data, isLoading, refetch } = useQuery<ConversationType[] | null>({
+  const { data, isFetching, isLoading, refetch } = useQuery<
+    ConversationType[] | null
+  >({
     queryKey: [QUERY_KEYS.CONVERSATIONS],
     queryFn: getConversations,
+    refetchInterval: 2000,
   });
 
   return {
     conversations: data,
     isConversationsLoading: isLoading,
+    isConversationsFetching: isFetching,
     conversationsRefetch: refetch,
   };
 };
 
 export const useFetchMessages = (userId: string) => {
-  const { data, isLoading, refetch } = useQuery<MessageType[] | null>({
-    queryKey: [QUERY_KEYS.MESSAGES],
-    queryFn: async () => {
-      const messages = await getMessages(userId);
-      return messages
-        ? messages.sort(
-            (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt),
-          )
-        : [];
-    },
-    enabled: !!userId,
-  });
+  const { data, isFetching, isFetchedAfterMount, isLoading, refetch } =
+    useQuery<MessageType[] | null>({
+      queryKey: [QUERY_KEYS.MESSAGES],
+      queryFn: async () => {
+        const messages = await getMessages(userId);
+        return messages
+          ? messages.sort(
+              (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt),
+            )
+          : [];
+      },
+      refetchInterval: 2000,
+      enabled: !!userId,
+    });
 
   return {
+    isMessagesFetchedAfterMount: isFetchedAfterMount,
     messages: data,
+    isMessagesFetching: isFetching,
     isMessagesLoading: isLoading,
     messagesRefetch: refetch,
   };
 };
 
-/* 이 밑으로 아직 사용 안하는 중 */
-
-export const useCreateMessage = ({
-  message,
-  receiver,
-}: PostCreateMessageRequestType) => {
-  const { data, isError, isSuccess } = useMutation({
-    mutationFn: () => createMessage({ message, receiver }),
+export const useCreateMessage = (onError?: () => void) => {
+  const { data, mutate, isError, isSuccess, mutateAsync } = useMutation({
+    mutationFn: ({ message, receiver }: PostCreateMessageRequestType) =>
+      createMessage({ message, receiver }),
+    onError,
   });
 
   return {
-    message: data,
+    createdMessage: data,
+    mutateCreateMessage: mutate,
     isCreateMessageError: isError,
     isCreateMessageSuccess: isSuccess,
+    mutateAsync,
   };
 };
 
 export const useReadMessage = () => {
   const queryClient = useQueryClient();
 
-  const { mutate } = useMutation({
+  const { mutate, isError } = useMutation({
     mutationFn: (userId: string) => readMessage(userId),
     onSettled: () => {
       queryClient.refetchQueries({ queryKey: [QUERY_KEYS.CONVERSATIONS] });
@@ -74,5 +81,6 @@ export const useReadMessage = () => {
 
   return {
     mutateReadMessage: mutate,
+    isReadMessageError: isError,
   };
 };

--- a/src/Hooks/Api/Notification/index.ts
+++ b/src/Hooks/Api/Notification/index.ts
@@ -14,10 +14,10 @@ export const useGetNotifications = () => {
   };
 };
 
-export const useCreateNotification = () => {
+export const useCreateNotification = (onError?: () => void) => {
   const queryClient = useQueryClient();
 
-  const { mutate: createNotification } = useMutation({
+  const { mutate: createNotification, data } = useMutation({
     mutationFn: ({
       notificationType,
       notificationTypeId,
@@ -30,10 +30,11 @@ export const useCreateNotification = () => {
         userId,
         postId,
       }),
+    onError,
     onSettled: () => {
       queryClient.refetchQueries({ queryKey: [QUERY_KEYS.NOTIFICATION_LIST] });
     },
   });
 
-  return { createNotification };
+  return { createNotification, createdNotification: data };
 };

--- a/src/Pages/DetailPage/PostDetailModal/index.tsx
+++ b/src/Pages/DetailPage/PostDetailModal/index.tsx
@@ -66,7 +66,7 @@ const PostDetailModal = ({
   const { colors, size } = useTheme();
   const { postId } = useParams();
   const { user: authUser } = useAuthUserStore();
-  const { setReceiver } = useMessageReceiver();
+  const { setReceiver, setIsClickedUserCard } = useMessageReceiver();
   const { mutateReadMessage } = useReadMessage();
 
   const commentInputRef = useRef<HTMLInputElement>(null);
@@ -135,6 +135,7 @@ const PostDetailModal = ({
     if (postDetailData) {
       if (postDetailData.author._id !== authUser._id) {
         setReceiver(postDetailData.author);
+        setIsClickedUserCard(true);
         mutateReadMessage(postDetailData.author._id);
       } else {
         setReceiver(null);

--- a/src/Pages/DirectMessagePage/index.tsx
+++ b/src/Pages/DirectMessagePage/index.tsx
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 /* eslint-disable no-underscore-dangle */
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { StyledContainer, StyledDiv } from './style';
 import MessageList from '@/Components/DirectMessage/MessageList';
 import ConversationList from '@/Components/DirectMessage/ConversationList';
-import { useFetchConversations } from '@/Hooks/Api/Message';
 import useAuthUserStore from '@/Stores/AuthUser';
 import useMessageReceiver from '@/Stores/MessageReceiver';
 import useResize from '@/Hooks/useResize';
@@ -13,13 +12,10 @@ import useCheckAuth from '@/Hooks/Api/Auth';
 
 const DirectMessagePage = () => {
   const navigator = useNavigate();
-  const [isClickedUserCard, setIsClickedUserCard] = useState(false);
-  const { conversations, isConversationsLoading, conversationsRefetch } =
-    useFetchConversations();
-  const { setAuthUser, user } = useAuthUserStore();
-  const { receiver, setReceiver } = useMessageReceiver();
   const { isMobileSize } = useResize();
   const { loginUserData, isCheckAuthSuccess } = useCheckAuth();
+  const { setAuthUser, user } = useAuthUserStore();
+  const { receiver, isClickedUserCard } = useMessageReceiver();
 
   useEffect(() => {
     if (!isCheckAuthSuccess) return;
@@ -35,11 +31,6 @@ const DirectMessagePage = () => {
   const conversationList = (
     <ConversationList
       isMobileSize={isMobileSize}
-      setIsClickedUserCard={setIsClickedUserCard}
-      setReceiver={setReceiver}
-      conversations={conversations}
-      isConversationsLoading={isConversationsLoading}
-      conversationsRefetch={conversationsRefetch}
       loginUser={user}
     />
   );
@@ -47,10 +38,7 @@ const DirectMessagePage = () => {
   const messageList = receiver && (
     <MessageList
       isMobileSize={isMobileSize}
-      isClickedUserCard={isClickedUserCard}
-      setIsClickedUserCard={setIsClickedUserCard}
       receiver={receiver}
-      conversationsRefetch={conversationsRefetch}
       loginUser={user}
     />
   );

--- a/src/Stores/MessageReceiver/index.ts
+++ b/src/Stores/MessageReceiver/index.ts
@@ -5,6 +5,8 @@ import { UserType } from '@/Types/UserType';
 const useMessageReceiver = create<MessageReceiverType>((set) => ({
   receiver: null,
   setReceiver: (receiver: UserType | null) => set({ receiver }),
+  isClickedUserCard: false,
+  setIsClickedUserCard: (state: boolean) => set({ isClickedUserCard: state }),
 }));
 
 export default useMessageReceiver;

--- a/src/Stores/MessageReceiver/type.ts
+++ b/src/Stores/MessageReceiver/type.ts
@@ -3,4 +3,6 @@ import { UserType } from '@/Types/UserType';
 export interface MessageReceiverType {
   receiver: UserType | null;
   setReceiver: (user: UserType | null) => void;
+  isClickedUserCard: boolean;
+  setIsClickedUserCard: (state: boolean) => void;
 }


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/RefactorDirectMessage3` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
- 스켈레톤은 처음 로딩될 때만 길게 적용, 이후 짧게 적용됩니다.
- 실시간 대화가 가능하도록 conversations, messages를 2초에 한번씩 불러오도록 `refetchInterval` 옵션을 주었습니다.
- 상대방과의 채팅방이 켜져있고, messages가 refetch될 때 알림도 같이 읽도록 적용했습니다.
- 글쓰기 버튼 hover시 검은색 배경이 생기던 현상을 수정했습니다.
- isClickedUserCard 상태를 전역 스토어로 분리했습니다.
- 코드를 정리했습니다. 기존에 자식에게 Props로 전달하던 것들을 해당 자식 컴포넌트에서 직접 스토어에서 꺼내서 사용하는 방식으로 변경했습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] DirectMessage 전부 변경
- [x] 다이렉트 메세지로 라우팅 하는 곳에서 `setIsClickedUserCard(true)` 호출하도록 변경
- [x] Message, Notification react-query 커스텀 훅 옵션 변경
- [x] UserCard 글자 색 변경, 시간을 클릭했을 때 씹히던 현상 해결

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
.