### PR TITLE
Refactor: getChannel API 함수 내부에서 채널 이름이 한글인 경우 인코딩 작업 추가

### DIFF
--- a/src/Services/Channel/index.ts
+++ b/src/Services/Channel/index.ts
@@ -24,8 +24,18 @@ export const getChannels = async () => {
  */
 export const getChannel = async (channelName: string) => {
   try {
+    const Encoding = (keyword: string) => {
+      const isKorean = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/; // 한글인지 식별해주기 위한 정규표현식
+
+      if (keyword.match(isKorean)) {
+        const encodeKeyword = encodeURI(keyword); // 한글 인코딩
+        return encodeKeyword;
+      }
+      return keyword;
+    };
+
     const res = await axiosCommonInstance.get<ChannelType>(
-      DOMAIN.CHANNEL(channelName),
+      DOMAIN.CHANNEL(Encoding(channelName)),
     );
 
     return res.data;


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/createChannelEncoding` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
getChannel 함수 내부에서 만약 채널명이 한글인 경우, 인코딩 작업을 거친 뒤 API를 호출하도록 수정했습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] Service/Channel의 getChannel 함수 수정

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 테스트 해봤는데 채널 정보가 잘 내려옵니다!
- 그런데 테스트 해본 결과 인코딩 안해도 잘 오는 것 같습니다....😮 그래도 요구사항이니 혹시 몰라서 인코딩 작업 추가했습니다!