### PR TITLE
Fix: 포스트 추가 모달에서 Channel 드롭다운 매핑 문제 해결

### DIFF
--- a/src/Components/Common/Modal/AddOrEditPostModal/AsideHeader/index.tsx
+++ b/src/Components/Common/Modal/AddOrEditPostModal/AsideHeader/index.tsx
@@ -9,6 +9,8 @@ import { StyledContainer, StyledHeader, StyledWrapper } from './style';
 import channels from '@/Constants/Channels';
 import { checkAuth } from '@/Services/Auth';
 import { Props } from './type';
+import QUERY_KEYS from '@/Constants/queryKeys';
+import { getChannels } from '@/Services/Channel';
 
 /**
  * @brief 채널 선택 드롭다운, 포스트 작성 제출 버튼, 유저 프로필 정보를 담고 있는 AisdeHeader 컴포넌트입니다.
@@ -21,17 +23,24 @@ const AsideHeader = ({ onSelectChannel, onSubmit, initialValue }: Props) => {
     queryFn: checkAuth,
   });
 
-  const reversedChannel = Object.entries(channels).reduce(
-    (acc: Record<string, string>, [key, value]) => {
-      acc[value] = key;
-      return acc;
-    },
-    {},
-  );
+  const { data: channelList } = useQuery({
+    queryKey: [QUERY_KEYS.CHANNEL_LIST],
+    queryFn: getChannels,
+  });
+
+  // 채널명 배열
+  const channelNameList = channelList
+    ?.map((channel) => {
+      if (Object.keys(channels).includes(channel.name)) {
+        return channels[channel.name];
+      }
+      return channel.name;
+    })
+    .filter((channelName) => channelName);
 
   const handleSelect = async (option: string) => {
     if (onSelectChannel) {
-      onSelectChannel(reversedChannel[option]);
+      onSelectChannel(option);
     }
   };
 
@@ -39,7 +48,7 @@ const AsideHeader = ({ onSelectChannel, onSubmit, initialValue }: Props) => {
     <StyledWrapper>
       <StyledHeader>
         <DropDown // 카테고리 드롭다운
-          options={Object.values(channels)}
+          options={channelNameList || []}
           onSelect={handleSelect}
           initialValue={initialValue}
         />


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/fixAddPost` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
포스트 추가 모달에서 채널 드롭다운이 연동되지 않는 문제를 해결했습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] 기존 Constants의 채널 매핑이 아니라 서버에서 불러온 채널 리스트를 사용

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 급한 건입니다! approve 해주세요!
