### PR TITLE
Fix: 팔로우 연타 시 중복으로 들어가던 현상 debounce로 해결

### DIFF
--- a/src/Components/FollowModal/index.tsx
+++ b/src/Components/FollowModal/index.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable no-underscore-dangle */
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { debounce } from 'lodash';
 import Input from '../Base/Input';
 import Modal from '../Common/Modal';
 import UserCard from '../Common/UserCard';
@@ -123,6 +124,8 @@ const FollowModal = ({
     await fetchFollowData();
   };
 
+  const debouncedHandleFollow = debounce(handleFollow, 300);
+
   const handleClickUser = (userId: string) => {
     navigator(`/profile/${userId}`);
     onChangeOpen(false);
@@ -172,7 +175,7 @@ const FollowModal = ({
                 isFollow={isFollowing(user)}
                 isButtonShow={isButtonShow(user._id)}
                 onClick={() => handleClickUser(user._id)}
-                onClickFollowBtn={() => handleFollow(user)}
+                onClickFollowBtn={() => debouncedHandleFollow(user)}
               />
             ))
           )}

--- a/src/Components/Profile/ProfileInfo/UserProfileInfo/index.tsx
+++ b/src/Components/Profile/ProfileInfo/UserProfileInfo/index.tsx
@@ -2,6 +2,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTheme } from 'styled-components';
 import { useState } from 'react';
+import { debounce } from 'lodash';
 import Button from '@/Components/Base/Button';
 import { StyledButtonContainer, StyledName } from '../style';
 import { NameProps } from './type';
@@ -54,6 +55,8 @@ const UserProfileInfo = ({ name, user, isFollowing }: NameProps) => {
     userDataRefetch();
   };
 
+  const debouncedHandleFollow = debounce(handleFollow, 300);
+
   const handleDirectMessage = () => {
     if (Object.keys(authUser).length === 0) {
       setErrorMode('MESSAGE');
@@ -78,7 +81,7 @@ const UserProfileInfo = ({ name, user, isFollowing }: NameProps) => {
           borderRadius="1rem"
           backgroundColor={colors.read}
           style={{ marginRight: '1rem', marginTop: '.5rem' }}
-          onClick={handleFollow}
+          onClick={debouncedHandleFollow}
         >
           팔로잉
         </Button>
@@ -95,7 +98,7 @@ const UserProfileInfo = ({ name, user, isFollowing }: NameProps) => {
             marginTop: '.5rem',
             border: `1px solid ${colors.text}`,
           }}
-          onClick={handleFollow}
+          onClick={debouncedHandleFollow}
         >
           팔로우
         </Button>


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`feature/FixFollowModal2` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
- 팔로우 모달, 유저 상세 페이지에서 팔로우 버튼을 연타하는 경우 중복으로 들어가는 현상이 발견되어 debounce로 해결했습니다.

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] FollowModal, UserProfileInfo 수정

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
.
